### PR TITLE
fix: strip comments and blank lines from .env before export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #ex: make run func=HelloGet
 run:
-	@export $$(cat .env | xargs) && FUNCTION_TARGET=$(func) PORT=$(port) TIME=$(time) go run cmd/main.go
+	@export $$(grep -v '^\s*#' .env | grep -v '^\s*$$' | xargs) && FUNCTION_TARGET=$(func) PORT=$(port) TIME=$(time) go run cmd/main.go
 
 run-weekly-get:
 	@make run func=WeeklyGet port=8199


### PR DESCRIPTION
## Summary
- Fixes `make run` to ignore comment lines and blank lines in `.env` when exporting variables
- Uses `grep` to filter out lines starting with `#` and empty lines before passing to `xargs`

## Test plan
- [ ] Add comments and blank lines to `.env` and verify `make run` still works correctly
- [ ] Verify environment variables are still exported properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)