### PR TITLE
feat: Amplop v2 Phase 2 — persistence layer (repos + effective-date resolution)

### DIFF
--- a/internal/budget/model.go
+++ b/internal/budget/model.go
@@ -1,0 +1,19 @@
+package budget
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Config is one effective-dated budget configuration row.
+type Config struct {
+	ID             uuid.UUID `db:"id"`
+	EffectiveYear  int16     `db:"effective_year"`
+	EffectiveMonth int16     `db:"effective_month"`
+	Monthly        int64     `db:"monthly"`
+	ShopWeekly     int64     `db:"shop_weekly"`
+	WeekendBudget  int64     `db:"weekend_budget"`
+	CreatedAt      time.Time `db:"created_at"`
+	UpdatedAt      time.Time `db:"updated_at"`
+}

--- a/internal/budget/repo.go
+++ b/internal/budget/repo.go
@@ -1,0 +1,62 @@
+package budget
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+)
+
+// Repo provides access to the amplop.budget_config table.
+type Repo struct {
+	db *sqlx.DB
+}
+
+// NewRepo creates a new Repo backed by db.
+func NewRepo(db *sqlx.DB) *Repo {
+	return &Repo{db: db}
+}
+
+// Resolve returns the effective budget config for (year, month) using the §5.1
+// tuple-comparison resolution query. The 2025-01 baseline ensures a row always
+// exists for any viewable month; NotFound is returned as a defensive fallback.
+func (r *Repo) Resolve(ctx context.Context, year, month int) (Config, error) {
+	const q = `
+SELECT id, effective_year, effective_month, monthly, shop_weekly, weekend_budget,
+       created_at, updated_at
+FROM amplop.budget_config
+WHERE (effective_year, effective_month) <= ($1, $2)
+ORDER BY effective_year DESC, effective_month DESC
+LIMIT 1`
+	var cfg Config
+	if err := r.db.GetContext(ctx, &cfg, q, year, month); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Config{}, apierr.NotFound("no budget config for %d-%02d", year, month)
+		}
+		return Config{}, fmt.Errorf("budget resolve %d-%02d: %w", year, month, err)
+	}
+	return cfg, nil
+}
+
+// Upsert writes a budget config version effective from (year, month), per §5.2.
+// Calling this with the current month freezes past months and applies forward.
+func (r *Repo) Upsert(ctx context.Context, year, month int, monthly, shopWeekly, weekendBudget int64) error {
+	const q = `
+INSERT INTO amplop.budget_config
+    (effective_year, effective_month, monthly, shop_weekly, weekend_budget, updated_at)
+VALUES ($1, $2, $3, $4, $5, current_timestamp())
+ON CONFLICT (effective_year, effective_month)
+DO UPDATE SET
+    monthly        = EXCLUDED.monthly,
+    shop_weekly    = EXCLUDED.shop_weekly,
+    weekend_budget = EXCLUDED.weekend_budget,
+    updated_at     = current_timestamp()`
+	if _, err := r.db.ExecContext(ctx, q, year, month, monthly, shopWeekly, weekendBudget); err != nil {
+		return fmt.Errorf("budget upsert %d-%02d: %w", year, month, err)
+	}
+	return nil
+}

--- a/internal/budget/repo_test.go
+++ b/internal/budget/repo_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package budget
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+)
+
+func connectTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	host := os.Getenv("DB_HOST")
+	if host == "" {
+		t.Skip("DB_HOST not set; skipping integration test")
+	}
+	dsn := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslrootcert=%s sslmode=verify-full",
+		host, os.Getenv("DB_PORT"), os.Getenv("DB_USER"),
+		os.Getenv("DB_PASSWORD"), os.Getenv("DB_NAME"), os.Getenv("DB_SSL_ROOT_CERT"),
+	)
+	db, err := sqlx.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestResolve_Baseline(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	// The 2025-01 baseline is always present; any month ≥ 2025-01 resolves to it
+	// (or a later version if one has been upserted, which won't happen here since
+	// TestUpsert_EffectiveDating uses year 2099 to avoid collision).
+	cfg, err := repo.Resolve(ctx, 2026, 6)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cfg.Monthly == 0 {
+		t.Errorf("expected non-zero Monthly, got 0")
+	}
+	if cfg.ShopWeekly == 0 {
+		t.Errorf("expected non-zero ShopWeekly, got 0")
+	}
+}
+
+func TestResolve_NotFound(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	// No row exists before the 2025-01 baseline.
+	_, err := repo.Resolve(ctx, 2024, 12)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestUpsert_EffectiveDating(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	// Use far-future year to avoid collision with real data.
+	const testYear = 2099
+	t.Cleanup(func() {
+		db.ExecContext(ctx, `DELETE FROM amplop.budget_config WHERE effective_year = $1`, testYear) //nolint:errcheck
+	})
+
+	// Insert a new version at (2099, 3).
+	if err := repo.Upsert(ctx, testYear, 3, 9_000_000, 900_000, 300_000); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	// Month before the new version resolves to the previous row (not 2099-03 values).
+	before, err := repo.Resolve(ctx, testYear, 2)
+	if err != nil {
+		t.Fatalf("Resolve before: %v", err)
+	}
+	if before.Monthly == 9_000_000 {
+		t.Error("month before new version should not return new values")
+	}
+
+	// Exactly at and after the new version returns new values.
+	for _, m := range []int{3, 4, 12} {
+		cfg, err := repo.Resolve(ctx, testYear, m)
+		if err != nil {
+			t.Fatalf("Resolve(%d, %d): %v", testYear, m, err)
+		}
+		if cfg.Monthly != 9_000_000 {
+			t.Errorf("month %d: Monthly=%d, want 9000000", m, cfg.Monthly)
+		}
+		if cfg.ShopWeekly != 900_000 {
+			t.Errorf("month %d: ShopWeekly=%d, want 900000", m, cfg.ShopWeekly)
+		}
+	}
+
+	// Re-upsert at the same month updates the row in place.
+	if err := repo.Upsert(ctx, testYear, 3, 8_000_000, 800_000, 250_000); err != nil {
+		t.Fatalf("second Upsert: %v", err)
+	}
+	updated, err := repo.Resolve(ctx, testYear, 3)
+	if err != nil {
+		t.Fatalf("Resolve after update: %v", err)
+	}
+	if updated.Monthly != 8_000_000 {
+		t.Errorf("after re-upsert: Monthly=%d, want 8000000", updated.Monthly)
+	}
+}

--- a/internal/expense/model.go
+++ b/internal/expense/model.go
@@ -1,0 +1,40 @@
+package expense
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// Expense is the full DB representation of one amplop.expense row.
+// occurred_year and occurred_month are generated columns stored by the DB from
+// occurred_date; they are populated on SELECT/RETURNING but must never appear
+// in an INSERT column list.
+type Expense struct {
+	ID             uuid.UUID  `db:"id"`
+	OccurredDate   time.Time  `db:"occurred_date"`
+	OccurredTime   *time.Time `db:"occurred_time"` // lib/pq: SQL TIME → time.Time with date 0001-01-01
+	Amount         int64      `db:"amount"`
+	Category       string     `db:"category"`
+	SubscriptionID *uuid.UUID `db:"subscription_id"`
+	Note           string     `db:"note"`
+	OccurredYear   int16      `db:"occurred_year"`
+	OccurredMonth  int16      `db:"occurred_month"`
+	CreatedAt      time.Time  `db:"created_at"`
+	UpdatedAt      time.Time  `db:"updated_at"`
+}
+
+// OccurredAt reconstructs the Asia/Jakarta wall-clock instant of the expense.
+// lib/pq returns SQL DATE as midnight UTC; .In(Loc).Date() extracts the correct
+// Jakarta calendar date. SQL TIME clock-face hours are in UTC on the 0001-01-01
+// origin, so we read them with .UTC() before combining with the date.
+func (e Expense) OccurredAt() time.Time {
+	y, m, d := e.OccurredDate.In(timeutil.Loc).Date()
+	if e.OccurredTime == nil {
+		return time.Date(y, m, d, 0, 0, 0, 0, timeutil.Loc)
+	}
+	t := e.OccurredTime.UTC()
+	return time.Date(y, m, d, t.Hour(), t.Minute(), t.Second(), 0, timeutil.Loc)
+}

--- a/internal/expense/repo.go
+++ b/internal/expense/repo.go
@@ -33,12 +33,15 @@ func NewRepo(db *sqlx.DB) *Repo {
 // The envelope engine attributes each expense precisely; the wider query ensures
 // cross-boundary weeks and weekends are included.
 func (r *Repo) ForMonth(ctx context.Context, year, month int) ([]Expense, error) {
-	from := timeutil.FirstOfMonth(year, month).AddDate(0, 0, -7)
-	to := timeutil.LastOfMonth(year, month).AddDate(0, 0, 7)
+	// Format as YYYY-MM-DD strings and cast with ::date so the comparison is
+	// DATE-to-DATE, avoiding a timestamptz conversion whose result depends on the
+	// DB session timezone (midnight Jakarta ≠ midnight UTC).
+	from := timeutil.FirstOfMonth(year, month).AddDate(0, 0, -7).Format("2006-01-02")
+	to := timeutil.LastOfMonth(year, month).AddDate(0, 0, 7).Format("2006-01-02")
 	const q = `
 SELECT ` + selectCols + `
 FROM amplop.expense
-WHERE occurred_date >= $1 AND occurred_date <= $2
+WHERE occurred_date >= $1::date AND occurred_date <= $2::date
 ORDER BY occurred_date, occurred_time NULLS FIRST, created_at`
 	var out []Expense
 	if err := r.db.SelectContext(ctx, &out, q, from, to); err != nil {

--- a/internal/expense/repo.go
+++ b/internal/expense/repo.go
@@ -1,0 +1,165 @@
+package expense
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+const selectCols = `id, occurred_date, occurred_time, amount, category, subscription_id,
+       note, occurred_year, occurred_month, created_at, updated_at`
+
+// Repo provides access to the amplop.expense table.
+type Repo struct {
+	db *sqlx.DB
+}
+
+// NewRepo creates a new Repo backed by db.
+func NewRepo(db *sqlx.DB) *Repo {
+	return &Repo{db: db}
+}
+
+// ForMonth returns all expenses in the wide boundary window
+// [firstOfMonth−7d, lastOfMonth+7d] for (year, month), per §6.2.
+// The envelope engine attributes each expense precisely; the wider query ensures
+// cross-boundary weeks and weekends are included.
+func (r *Repo) ForMonth(ctx context.Context, year, month int) ([]Expense, error) {
+	from := timeutil.FirstOfMonth(year, month).AddDate(0, 0, -7)
+	to := timeutil.LastOfMonth(year, month).AddDate(0, 0, 7)
+	const q = `
+SELECT ` + selectCols + `
+FROM amplop.expense
+WHERE occurred_date >= $1 AND occurred_date <= $2
+ORDER BY occurred_date, occurred_time NULLS FIRST, created_at`
+	var out []Expense
+	if err := r.db.SelectContext(ctx, &out, q, from, to); err != nil {
+		return nil, fmt.Errorf("expenses for month %d-%02d: %w", year, month, err)
+	}
+	return out, nil
+}
+
+// ByID returns the expense with the given id.
+func (r *Repo) ByID(ctx context.Context, id uuid.UUID) (Expense, error) {
+	const q = `SELECT ` + selectCols + ` FROM amplop.expense WHERE id = $1`
+	var e Expense
+	if err := r.db.GetContext(ctx, &e, q, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Expense{}, apierr.NotFound("expense %s not found", id)
+		}
+		return Expense{}, fmt.Errorf("expense by id %s: %w", id, err)
+	}
+	return e, nil
+}
+
+// Create inserts a new expense and returns the fully-populated row (DB-generated
+// id, occurred_year, occurred_month, timestamps filled via RETURNING).
+// occurred_year and occurred_month must not appear in the INSERT column list —
+// they are generated columns computed by the DB from occurred_date.
+func (r *Repo) Create(ctx context.Context, e Expense) (Expense, error) {
+	const q = `
+INSERT INTO amplop.expense (occurred_date, occurred_time, amount, category, subscription_id, note)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING ` + selectCols
+	var created Expense
+	err := r.db.GetContext(ctx, &created, q,
+		e.OccurredDate, e.OccurredTime, e.Amount, e.Category, e.SubscriptionID, e.Note)
+	if err != nil {
+		return Expense{}, mapUniqueErr(err, "create expense")
+	}
+	return created, nil
+}
+
+// Update replaces all mutable fields of an existing expense.
+func (r *Repo) Update(ctx context.Context, e Expense) (Expense, error) {
+	const q = `
+UPDATE amplop.expense
+SET occurred_date   = $2,
+    occurred_time   = $3,
+    amount          = $4,
+    category        = $5,
+    subscription_id = $6,
+    note            = $7,
+    updated_at      = current_timestamp()
+WHERE id = $1
+RETURNING ` + selectCols
+	var updated Expense
+	err := r.db.GetContext(ctx, &updated, q,
+		e.ID, e.OccurredDate, e.OccurredTime, e.Amount, e.Category, e.SubscriptionID, e.Note)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Expense{}, apierr.NotFound("expense %s not found", e.ID)
+		}
+		return Expense{}, mapUniqueErr(err, "update expense")
+	}
+	return updated, nil
+}
+
+// Delete removes the expense with id.
+func (r *Repo) Delete(ctx context.Context, id uuid.UUID) error {
+	const q = `DELETE FROM amplop.expense WHERE id = $1`
+	res, err := r.db.ExecContext(ctx, q, id)
+	if err != nil {
+		return fmt.Errorf("delete expense %s: %w", id, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return apierr.NotFound("expense %s not found", id)
+	}
+	return nil
+}
+
+// ExistsForSubscriptionMonth reports whether a Langganan expense already exists
+// for (subscriptionID, year, month). When excludeID is non-nil the check skips
+// that row — used on update to avoid flagging the row being edited as a conflict.
+// This is the service-layer pre-check; the DB unique index is the backstop.
+func (r *Repo) ExistsForSubscriptionMonth(ctx context.Context, subscriptionID uuid.UUID, year, month int, excludeID *uuid.UUID) (bool, error) {
+	var (
+		q    string
+		args []any
+	)
+	if excludeID == nil {
+		q = `SELECT EXISTS (
+    SELECT 1 FROM amplop.expense
+    WHERE subscription_id = $1
+      AND occurred_year   = $2
+      AND occurred_month  = $3
+)`
+		args = []any{subscriptionID, year, month}
+	} else {
+		q = `SELECT EXISTS (
+    SELECT 1 FROM amplop.expense
+    WHERE subscription_id = $1
+      AND occurred_year   = $2
+      AND occurred_month  = $3
+      AND id != $4
+)`
+		args = []any{subscriptionID, year, month, *excludeID}
+	}
+	var exists bool
+	if err := r.db.GetContext(ctx, &exists, q, args...); err != nil {
+		return false, fmt.Errorf("exists for subscription month: %w", err)
+	}
+	return exists, nil
+}
+
+// mapUniqueErr converts the DB unique-index violation on
+// expense_one_sub_payment_per_month into an apierr.Conflict as a backstop for
+// the once-per-month rule. All other errors are wrapped and returned unchanged.
+func mapUniqueErr(err error, op string) error {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) &&
+		pqErr.Code == "23505" &&
+		strings.Contains(pqErr.Constraint, "expense_one_sub_payment_per_month") {
+		return apierr.Conflict("subscription already paid this month")
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}

--- a/internal/expense/repo_test.go
+++ b/internal/expense/repo_test.go
@@ -1,0 +1,416 @@
+//go:build integration
+
+package expense
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+func connectTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	host := os.Getenv("DB_HOST")
+	if host == "" {
+		t.Skip("DB_HOST not set; skipping integration test")
+	}
+	dsn := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslrootcert=%s sslmode=verify-full",
+		host, os.Getenv("DB_PORT"), os.Getenv("DB_USER"),
+		os.Getenv("DB_PASSWORD"), os.Getenv("DB_NAME"), os.Getenv("DB_SSL_ROOT_CERT"),
+	)
+	db, err := sqlx.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// createTestSub inserts a bare subscription identity row (no version needed for
+// FK references) and registers cleanup. Returns the new subscription ID.
+func createTestSub(t *testing.T, db *sqlx.DB, name string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	var id uuid.UUID
+	err := db.GetContext(ctx, &id,
+		`INSERT INTO amplop.subscription (name, color) VALUES ($1, '') RETURNING id`, name)
+	if err != nil {
+		t.Fatalf("createTestSub: %v", err)
+	}
+	t.Cleanup(func() {
+		db.ExecContext(ctx, `DELETE FROM amplop.subscription WHERE id = $1`, id) //nolint:errcheck
+	})
+	return id
+}
+
+// deleteExpenses removes a set of expense rows by ID. Called in t.Cleanup.
+func deleteExpenses(ctx context.Context, db *sqlx.DB, ids ...uuid.UUID) {
+	for _, id := range ids {
+		db.ExecContext(ctx, `DELETE FROM amplop.expense WHERE id = $1`, id) //nolint:errcheck
+	}
+}
+
+func TestForMonth_WideBoundaryWindow(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	// Jun 29, 2026 (Monday) — belongs to the week whose Friday is Jul 3, 2026.
+	// It should appear in July's ForMonth window but not in May's.
+	jun29 := Expense{
+		OccurredDate: timeutil.Date(2026, 6, 29),
+		Amount:       10_000,
+		Category:     "Belanja",
+		Note:         "boundary test jun29",
+	}
+	created1, err := repo.Create(ctx, jun29)
+	if err != nil {
+		t.Fatalf("Create jun29: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, created1.ID) })
+
+	// Jul 1, 2026 — falls inside June's +7d window (window extends to Jul 7).
+	jul1 := Expense{
+		OccurredDate: timeutil.Date(2026, 7, 1),
+		Amount:       20_000,
+		Category:     "Makan",
+		Note:         "boundary test jul1",
+	}
+	created2, err := repo.Create(ctx, jul1)
+	if err != nil {
+		t.Fatalf("Create jul1: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, created2.ID) })
+
+	containsID := func(expenses []Expense, id uuid.UUID) bool {
+		for _, e := range expenses {
+			if e.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Jun 29 should appear in July's window [Jun 24 … Aug 7].
+	julyExpenses, err := repo.ForMonth(ctx, 2026, 7)
+	if err != nil {
+		t.Fatalf("ForMonth July: %v", err)
+	}
+	if !containsID(julyExpenses, created1.ID) {
+		t.Error("Jun 29 expense should be included in July's wide window")
+	}
+
+	// Jun 29 must NOT appear in May's window [Apr 24 … Jun 7].
+	mayExpenses, err := repo.ForMonth(ctx, 2026, 5)
+	if err != nil {
+		t.Fatalf("ForMonth May: %v", err)
+	}
+	if containsID(mayExpenses, created1.ID) {
+		t.Error("Jun 29 expense must not be included in May's window")
+	}
+
+	// Jul 1 should appear in June's window [May 25 … Jul 7].
+	juneExpenses, err := repo.ForMonth(ctx, 2026, 6)
+	if err != nil {
+		t.Fatalf("ForMonth June: %v", err)
+	}
+	if !containsID(juneExpenses, created2.ID) {
+		t.Error("Jul 1 expense should be included in June's wide window")
+	}
+}
+
+func TestCreate_And_ByID(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	// Create with no time (nil OccurredTime).
+	e := Expense{
+		OccurredDate: timeutil.Date(2026, 6, 15),
+		Amount:       45_000,
+		Category:     "Makan",
+		Note:         "nasi padang",
+	}
+	created, err := repo.Create(ctx, e)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, created.ID) })
+
+	if created.ID == (uuid.UUID{}) {
+		t.Error("ID should be non-zero after Create")
+	}
+	if created.OccurredYear != 2026 {
+		t.Errorf("OccurredYear: got %d, want 2026", created.OccurredYear)
+	}
+	if created.OccurredMonth != 6 {
+		t.Errorf("OccurredMonth: got %d, want 6", created.OccurredMonth)
+	}
+	at := created.OccurredAt()
+	if at.Hour() != 0 || at.Minute() != 0 {
+		t.Errorf("OccurredAt without time: expected midnight Jakarta, got %v", at)
+	}
+	if at.Location() != timeutil.Loc {
+		t.Errorf("OccurredAt location: got %v, want %v", at.Location(), timeutil.Loc)
+	}
+
+	// ByID round-trip.
+	fetched, err := repo.ByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("ByID: %v", err)
+	}
+	if fetched.Amount != 45_000 {
+		t.Errorf("Amount: got %d, want 45000", fetched.Amount)
+	}
+	if fetched.Note != "nasi padang" {
+		t.Errorf("Note: got %q, want %q", fetched.Note, "nasi padang")
+	}
+
+	// Create with a non-nil time and verify OccurredAt preserves H:M:S.
+	// lib/pq stores SQL TIME as clock-face hours in UTC on 0001-01-01.
+	hm := time.Date(1, 1, 1, 14, 30, 0, 0, time.UTC)
+	e2 := Expense{
+		OccurredDate: timeutil.Date(2026, 6, 16),
+		OccurredTime: &hm,
+		Amount:       18_000,
+		Category:     "Jajan",
+		Note:         "es teh",
+	}
+	created2, err := repo.Create(ctx, e2)
+	if err != nil {
+		t.Fatalf("Create with time: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, created2.ID) })
+
+	at2 := created2.OccurredAt()
+	if at2.Hour() != 14 || at2.Minute() != 30 {
+		t.Errorf("OccurredAt with time: got %v, want 14:30 Jakarta", at2)
+	}
+}
+
+func TestByID_NotFound(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	_, err := repo.ByID(ctx, uuid.New())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestCreate_LanggananUniqueConstraint(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	subID := createTestSub(t, db, "Test Sub Unique 2026")
+
+	// First Langganan expense for the sub in June 2026.
+	e1 := Expense{
+		OccurredDate:   timeutil.Date(2026, 6, 5),
+		Amount:         186_000,
+		Category:       "Langganan",
+		SubscriptionID: &subID,
+		Note:           "first payment",
+	}
+	created1, err := repo.Create(ctx, e1)
+	if err != nil {
+		t.Fatalf("Create first Langganan: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, created1.ID) })
+
+	// Second Langganan for the same sub in the same month → DB backstop fires.
+	e2 := e1
+	e2.Note = "duplicate payment"
+	_, err = repo.Create(ctx, e2)
+	if err == nil {
+		t.Fatal("expected Conflict, got nil")
+	}
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindConflict {
+		t.Errorf("expected Conflict, got %v", err)
+	}
+
+	// A Langganan expense in a different month succeeds.
+	e3 := Expense{
+		OccurredDate:   timeutil.Date(2026, 7, 5),
+		Amount:         186_000,
+		Category:       "Langganan",
+		SubscriptionID: &subID,
+		Note:           "july payment",
+	}
+	created3, err := repo.Create(ctx, e3)
+	if err != nil {
+		t.Fatalf("Create Langganan different month: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, created3.ID) })
+}
+
+func TestExistsForSubscriptionMonth(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	subID := createTestSub(t, db, "Test Sub Exists 2026")
+
+	e := Expense{
+		OccurredDate:   timeutil.Date(2026, 6, 5),
+		Amount:         186_000,
+		Category:       "Langganan",
+		SubscriptionID: &subID,
+		Note:           "exists check",
+	}
+	created, err := repo.Create(ctx, e)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, created.ID) })
+
+	// Exists without exclude → true.
+	exists, err := repo.ExistsForSubscriptionMonth(ctx, subID, 2026, 6, nil)
+	if err != nil {
+		t.Fatalf("ExistsForSubscriptionMonth: %v", err)
+	}
+	if !exists {
+		t.Error("expected exists=true, got false")
+	}
+
+	// Exists excluding the row itself → false (update-self case).
+	exists, err = repo.ExistsForSubscriptionMonth(ctx, subID, 2026, 6, &created.ID)
+	if err != nil {
+		t.Fatalf("ExistsForSubscriptionMonth with exclude: %v", err)
+	}
+	if exists {
+		t.Error("expected exists=false when excluding own row, got true")
+	}
+
+	// Different month → false.
+	exists, err = repo.ExistsForSubscriptionMonth(ctx, subID, 2026, 7, nil)
+	if err != nil {
+		t.Fatalf("ExistsForSubscriptionMonth different month: %v", err)
+	}
+	if exists {
+		t.Error("expected exists=false for different month, got true")
+	}
+}
+
+func TestUpdate_And_Delete(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	e := Expense{
+		OccurredDate: timeutil.Date(2026, 6, 10),
+		Amount:       30_000,
+		Category:     "Lainnya",
+		Note:         "original",
+	}
+	created, err := repo.Create(ctx, e)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Update amount and note.
+	created.Amount = 35_000
+	created.Note = "updated"
+	updated, err := repo.Update(ctx, created)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Amount != 35_000 {
+		t.Errorf("Amount after Update: got %d, want 35000", updated.Amount)
+	}
+	if updated.Note != "updated" {
+		t.Errorf("Note after Update: got %q, want %q", updated.Note, "updated")
+	}
+
+	// Delete.
+	if err := repo.Delete(ctx, created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// ByID after delete → NotFound.
+	_, err = repo.ByID(ctx, created.ID)
+	if err == nil {
+		t.Fatal("expected NotFound after Delete, got nil")
+	}
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+
+	// Delete non-existent → NotFound.
+	err = repo.Delete(ctx, created.ID)
+	if err == nil {
+		t.Fatal("expected NotFound on second Delete, got nil")
+	}
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Errorf("expected NotFound on second Delete, got %v", err)
+	}
+}
+
+func TestUpdate_LanggananMove_Conflict(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	subID := createTestSub(t, db, "Test Sub Move 2026")
+
+	// Payment in June.
+	e1 := Expense{
+		OccurredDate:   timeutil.Date(2026, 6, 5),
+		Amount:         186_000,
+		Category:       "Langganan",
+		SubscriptionID: &subID,
+		Note:           "june payment",
+	}
+	c1, err := repo.Create(ctx, e1)
+	if err != nil {
+		t.Fatalf("Create June: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, c1.ID) })
+
+	// Payment in July.
+	e2 := Expense{
+		OccurredDate:   timeutil.Date(2026, 7, 5),
+		Amount:         186_000,
+		Category:       "Langganan",
+		SubscriptionID: &subID,
+		Note:           "july payment",
+	}
+	c2, err := repo.Create(ctx, e2)
+	if err != nil {
+		t.Fatalf("Create July: %v", err)
+	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, c2.ID) })
+
+	// Move the July payment into June → conflicts with the existing June payment.
+	c2.OccurredDate = timeutil.Date(2026, 6, 20)
+	_, err = repo.Update(ctx, c2)
+	if err == nil {
+		t.Fatal("expected Conflict when moving payment into occupied month, got nil")
+	}
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindConflict {
+		t.Errorf("expected Conflict, got %v", err)
+	}
+}

--- a/internal/expense/repo_test.go
+++ b/internal/expense/repo_test.go
@@ -328,6 +328,7 @@ func TestUpdate_And_Delete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	t.Cleanup(func() { deleteExpenses(ctx, db, created.ID) })
 
 	// Update amount and note.
 	created.Amount = 35_000

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -1,0 +1,43 @@
+package subscription
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Identity is the stable amplop.subscription row. Name and color are cosmetic
+// fields that are not effective-dated; they apply across all months.
+type Identity struct {
+	ID        uuid.UUID `db:"id"`
+	Name      string    `db:"name"`
+	Color     string    `db:"color"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// Version is one effective-dated attribute snapshot for a subscription.
+// A new Version is written each time alloc, due_day, or active changes;
+// reads use the latest Version with (effective_year, effective_month) ≤ viewed month.
+type Version struct {
+	ID             uuid.UUID `db:"id"`
+	SubscriptionID uuid.UUID `db:"subscription_id"`
+	EffectiveYear  int16     `db:"effective_year"`
+	EffectiveMonth int16     `db:"effective_month"`
+	Alloc          int64     `db:"alloc"`
+	DueDay         int16     `db:"due_day"`
+	Active         bool      `db:"active"`
+	CreatedAt      time.Time `db:"created_at"`
+	UpdatedAt      time.Time `db:"updated_at"`
+}
+
+// Resolved is an Identity joined to its effective Version for a given month,
+// as returned by the §5.1 lateral resolution query. Active is omitted — the
+// query already filters WHERE v.active = true.
+type Resolved struct {
+	ID     uuid.UUID `db:"id"`
+	Name   string    `db:"name"`
+	Color  string    `db:"color"`
+	Alloc  int64     `db:"alloc"`
+	DueDay int16     `db:"due_day"`
+}

--- a/internal/subscription/repo.go
+++ b/internal/subscription/repo.go
@@ -1,0 +1,145 @@
+package subscription
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+)
+
+// Repo provides access to amplop.subscription and amplop.subscription_version.
+type Repo struct {
+	db *sqlx.DB
+}
+
+// NewRepo creates a new Repo backed by db.
+func NewRepo(db *sqlx.DB) *Repo {
+	return &Repo{db: db}
+}
+
+// ListIdentities returns all subscription identity rows ordered by name.
+func (r *Repo) ListIdentities(ctx context.Context) ([]Identity, error) {
+	const q = `
+SELECT id, name, color, created_at, updated_at
+FROM amplop.subscription
+ORDER BY name`
+	var out []Identity
+	if err := r.db.SelectContext(ctx, &out, q); err != nil {
+		return nil, fmt.Errorf("list subscriptions: %w", err)
+	}
+	return out, nil
+}
+
+// ByID returns the subscription identity for id.
+func (r *Repo) ByID(ctx context.Context, id uuid.UUID) (Identity, error) {
+	const q = `
+SELECT id, name, color, created_at, updated_at
+FROM amplop.subscription
+WHERE id = $1`
+	var s Identity
+	if err := r.db.GetContext(ctx, &s, q, id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Identity{}, apierr.NotFound("subscription %s not found", id)
+		}
+		return Identity{}, fmt.Errorf("subscription by id %s: %w", id, err)
+	}
+	return s, nil
+}
+
+// Resolve returns the active subscription set for (year, month) using the §5.1
+// lateral join query. Returns an empty slice when no active subscriptions exist.
+func (r *Repo) Resolve(ctx context.Context, year, month int) ([]Resolved, error) {
+	const q = `
+SELECT s.id, s.name, s.color, v.alloc, v.due_day
+FROM amplop.subscription s
+JOIN LATERAL (
+    SELECT alloc, due_day, active
+    FROM amplop.subscription_version v
+    WHERE v.subscription_id = s.id
+      AND (v.effective_year, v.effective_month) <= ($1, $2)
+    ORDER BY v.effective_year DESC, v.effective_month DESC
+    LIMIT 1
+) v ON true
+WHERE v.active = true`
+	var out []Resolved
+	if err := r.db.SelectContext(ctx, &out, q, year, month); err != nil {
+		return nil, fmt.Errorf("resolve subscriptions %d-%02d: %w", year, month, err)
+	}
+	return out, nil
+}
+
+// CreateWithVersion inserts a subscription identity and its first effective-dated
+// version in a single transaction. year and month should be the current month
+// (from timeutil.CurrentMonth).
+func (r *Repo) CreateWithVersion(ctx context.Context, name, color string, year, month int, alloc int64, dueDay int16) (Identity, error) {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return Identity{}, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	const insertIdentity = `
+INSERT INTO amplop.subscription (name, color)
+VALUES ($1, $2)
+RETURNING id, name, color, created_at, updated_at`
+	var ident Identity
+	if err := tx.GetContext(ctx, &ident, insertIdentity, name, color); err != nil {
+		return Identity{}, fmt.Errorf("insert subscription: %w", err)
+	}
+
+	const insertVersion = `
+INSERT INTO amplop.subscription_version
+    (subscription_id, effective_year, effective_month, alloc, due_day, active)
+VALUES ($1, $2, $3, $4, $5, true)`
+	if _, err := tx.ExecContext(ctx, insertVersion, ident.ID, year, month, alloc, dueDay); err != nil {
+		return Identity{}, fmt.Errorf("insert subscription version: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return Identity{}, fmt.Errorf("commit subscription create: %w", err)
+	}
+	return ident, nil
+}
+
+// UpdateIdentity updates the cosmetic name and color of a subscription. These
+// apply to all months without versioning, per §5.2.
+func (r *Repo) UpdateIdentity(ctx context.Context, id uuid.UUID, name, color string) (Identity, error) {
+	const q = `
+UPDATE amplop.subscription
+SET name = $2, color = $3, updated_at = current_timestamp()
+WHERE id = $1
+RETURNING id, name, color, created_at, updated_at`
+	var s Identity
+	if err := r.db.GetContext(ctx, &s, q, id, name, color); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Identity{}, apierr.NotFound("subscription %s not found", id)
+		}
+		return Identity{}, fmt.Errorf("update subscription %s: %w", id, err)
+	}
+	return s, nil
+}
+
+// UpsertVersion writes an effective-dated version for (subscriptionID, year, month),
+// per §5.2. Pass active=false to soft-delete a subscription from the current month
+// onward. year and month should be the current month (from timeutil.CurrentMonth).
+func (r *Repo) UpsertVersion(ctx context.Context, subscriptionID uuid.UUID, year, month int, alloc int64, dueDay int16, active bool) error {
+	const q = `
+INSERT INTO amplop.subscription_version
+    (subscription_id, effective_year, effective_month, alloc, due_day, active, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, current_timestamp())
+ON CONFLICT (subscription_id, effective_year, effective_month)
+DO UPDATE SET
+    alloc      = EXCLUDED.alloc,
+    due_day    = EXCLUDED.due_day,
+    active     = EXCLUDED.active,
+    updated_at = current_timestamp()`
+	if _, err := r.db.ExecContext(ctx, q, subscriptionID, year, month, alloc, dueDay, active); err != nil {
+		return fmt.Errorf("upsert subscription version %s %d-%02d: %w", subscriptionID, year, month, err)
+	}
+	return nil
+}

--- a/internal/subscription/repo_test.go
+++ b/internal/subscription/repo_test.go
@@ -1,0 +1,275 @@
+//go:build integration
+
+package subscription
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+)
+
+func connectTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	host := os.Getenv("DB_HOST")
+	if host == "" {
+		t.Skip("DB_HOST not set; skipping integration test")
+	}
+	dsn := fmt.Sprintf(
+		"host=%s port=%s user=%s password=%s dbname=%s sslrootcert=%s sslmode=verify-full",
+		host, os.Getenv("DB_PORT"), os.Getenv("DB_USER"),
+		os.Getenv("DB_PASSWORD"), os.Getenv("DB_NAME"), os.Getenv("DB_SSL_ROOT_CERT"),
+	)
+	db, err := sqlx.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestCreateWithVersion_And_Resolve(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	ident, err := repo.CreateWithVersion(ctx, "Test Netflix 2099", "#c8403c", 2099, 1, 187_000, 5)
+	if err != nil {
+		t.Fatalf("CreateWithVersion: %v", err)
+	}
+	// CASCADE deletes subscription_version rows too.
+	t.Cleanup(func() {
+		db.ExecContext(ctx, `DELETE FROM amplop.subscription WHERE id = $1`, ident.ID) //nolint:errcheck
+	})
+
+	if ident.Name != "Test Netflix 2099" {
+		t.Errorf("Name: got %q, want %q", ident.Name, "Test Netflix 2099")
+	}
+	if ident.ID == (uuid.UUID{}) {
+		t.Error("ID should be non-zero")
+	}
+
+	// Visible at its effective month.
+	subs, err := repo.Resolve(ctx, 2099, 1)
+	if err != nil {
+		t.Fatalf("Resolve(2099,1): %v", err)
+	}
+	found := findResolved(subs, ident.ID)
+	if found == nil {
+		t.Fatal("subscription not found in Resolve(2099,1)")
+	}
+	if found.Alloc != 187_000 {
+		t.Errorf("Alloc: got %d, want 187000", found.Alloc)
+	}
+	if found.DueDay != 5 {
+		t.Errorf("DueDay: got %d, want 5", found.DueDay)
+	}
+
+	// Not visible before its effective month.
+	subs, err = repo.Resolve(ctx, 2098, 12)
+	if err != nil {
+		t.Fatalf("Resolve(2098,12): %v", err)
+	}
+	if findResolved(subs, ident.ID) != nil {
+		t.Error("subscription must not be visible before its effective month")
+	}
+}
+
+func TestUpsertVersion_EffectiveDating(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	ident, err := repo.CreateWithVersion(ctx, "Test Spotify 2099", "#1db954", 2099, 1, 100_000, 10)
+	if err != nil {
+		t.Fatalf("CreateWithVersion: %v", err)
+	}
+	t.Cleanup(func() {
+		db.ExecContext(ctx, `DELETE FROM amplop.subscription WHERE id = $1`, ident.ID) //nolint:errcheck
+	})
+
+	// Insert a newer version at (2099, 3) with higher alloc.
+	if err := repo.UpsertVersion(ctx, ident.ID, 2099, 3, 200_000, 10, true); err != nil {
+		t.Fatalf("UpsertVersion: %v", err)
+	}
+
+	cases := []struct {
+		month     int
+		wantAlloc int64
+	}{
+		{1, 100_000},  // original version still in effect
+		{2, 100_000},  // still original
+		{3, 200_000},  // new version takes over
+		{12, 200_000}, // new version applies forward
+	}
+	for _, tc := range cases {
+		subs, err := repo.Resolve(ctx, 2099, tc.month)
+		if err != nil {
+			t.Fatalf("Resolve(2099,%d): %v", tc.month, err)
+		}
+		r := findResolved(subs, ident.ID)
+		if r == nil {
+			t.Fatalf("Resolve(2099,%d): subscription not found", tc.month)
+		}
+		if r.Alloc != tc.wantAlloc {
+			t.Errorf("Resolve(2099,%d): Alloc=%d, want %d", tc.month, r.Alloc, tc.wantAlloc)
+		}
+	}
+
+	// Re-upsert at the same month updates in place.
+	if err := repo.UpsertVersion(ctx, ident.ID, 2099, 3, 250_000, 10, true); err != nil {
+		t.Fatalf("second UpsertVersion: %v", err)
+	}
+	subs, err := repo.Resolve(ctx, 2099, 3)
+	if err != nil {
+		t.Fatalf("Resolve after re-upsert: %v", err)
+	}
+	if r := findResolved(subs, ident.ID); r == nil || r.Alloc != 250_000 {
+		t.Errorf("after re-upsert: Alloc=%v, want 250000", func() any {
+			if r := findResolved(subs, ident.ID); r != nil {
+				return r.Alloc
+			}
+			return "not found"
+		}())
+	}
+}
+
+func TestUpsertVersion_SoftEnd(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	ident, err := repo.CreateWithVersion(ctx, "Test iCloud 2099", "#555555", 2099, 1, 50_000, 1)
+	if err != nil {
+		t.Fatalf("CreateWithVersion: %v", err)
+	}
+	t.Cleanup(func() {
+		db.ExecContext(ctx, `DELETE FROM amplop.subscription WHERE id = $1`, ident.ID) //nolint:errcheck
+	})
+
+	// Soft-delete at (2099, 2).
+	if err := repo.UpsertVersion(ctx, ident.ID, 2099, 2, 50_000, 1, false); err != nil {
+		t.Fatalf("UpsertVersion soft-end: %v", err)
+	}
+
+	// Still visible before the soft-end month.
+	subs, err := repo.Resolve(ctx, 2099, 1)
+	if err != nil {
+		t.Fatalf("Resolve(2099,1): %v", err)
+	}
+	if findResolved(subs, ident.ID) == nil {
+		t.Error("subscription must be visible before soft-end month")
+	}
+
+	// Invisible at and after the soft-end month.
+	for _, m := range []int{2, 3, 12} {
+		subs, err := repo.Resolve(ctx, 2099, m)
+		if err != nil {
+			t.Fatalf("Resolve(2099,%d): %v", m, err)
+		}
+		if findResolved(subs, ident.ID) != nil {
+			t.Errorf("subscription must not be visible at month 2099-%d after soft-end", m)
+		}
+	}
+}
+
+func TestByID_NotFound(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	_, err := repo.ByID(ctx, uuid.New())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestUpdateIdentity(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	ident, err := repo.CreateWithVersion(ctx, "Old Name", "#000000", 2099, 6, 30_000, 15)
+	if err != nil {
+		t.Fatalf("CreateWithVersion: %v", err)
+	}
+	t.Cleanup(func() {
+		db.ExecContext(ctx, `DELETE FROM amplop.subscription WHERE id = $1`, ident.ID) //nolint:errcheck
+	})
+
+	updated, err := repo.UpdateIdentity(ctx, ident.ID, "New Name", "#ffffff")
+	if err != nil {
+		t.Fatalf("UpdateIdentity: %v", err)
+	}
+	if updated.Name != "New Name" {
+		t.Errorf("Name: got %q, want %q", updated.Name, "New Name")
+	}
+	if updated.Color != "#ffffff" {
+		t.Errorf("Color: got %q, want %q", updated.Color, "#ffffff")
+	}
+
+	// Resolved still shows the new name.
+	subs, err := repo.Resolve(ctx, 2099, 6)
+	if err != nil {
+		t.Fatalf("Resolve after UpdateIdentity: %v", err)
+	}
+	r := findResolved(subs, ident.ID)
+	if r == nil {
+		t.Fatal("subscription not found after UpdateIdentity")
+	}
+	if r.Name != "New Name" {
+		t.Errorf("Resolved Name: got %q, want %q", r.Name, "New Name")
+	}
+}
+
+func TestListIdentities(t *testing.T) {
+	db := connectTestDB(t)
+	repo := NewRepo(db)
+	ctx := context.Background()
+
+	ident, err := repo.CreateWithVersion(ctx, "ZZZZ Test List 2099", "#aabbcc", 2099, 1, 10_000, 1)
+	if err != nil {
+		t.Fatalf("CreateWithVersion: %v", err)
+	}
+	t.Cleanup(func() {
+		db.ExecContext(ctx, `DELETE FROM amplop.subscription WHERE id = $1`, ident.ID) //nolint:errcheck
+	})
+
+	all, err := repo.ListIdentities(ctx)
+	if err != nil {
+		t.Fatalf("ListIdentities: %v", err)
+	}
+	var found bool
+	for _, s := range all {
+		if s.ID == ident.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("created subscription not found in ListIdentities")
+	}
+}
+
+func findResolved(subs []Resolved, id uuid.UUID) *Resolved {
+	for i := range subs {
+		if subs[i].ID == id {
+			return &subs[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR implements **Phase 2** of the Amplop v2 backend rewrite: the database persistence layer. Phases 0 (scaffold + platform) and 1 (pure envelope engine) landed in earlier PRs. Phase 2 adds three new packages under `internal/` — `budget`, `subscription`, and `expense` — each with a model, a repo, and integration tests. No services or HTTP handlers yet; those are Phase 3.

---

## What changed

### `internal/budget/`

- **`model.go`** — `Config` struct mapping to the `amplop.budget_config` table, with `db:` tags for sqlx.
- **`repo.go`** — `Repo` with two methods:
  - `Resolve(ctx, year, month)` — implements the §5.1 effective-date resolution query using a **tuple comparison** (`(effective_year, effective_month) <= ($1, $2)`) so CockroachDB uses the `UNIQUE (effective_year, effective_month)` index as a range scan. Returns `apierr.NotFound` defensively if nothing resolves (the 2025-01 baseline makes this unreachable in practice).
  - `Upsert(ctx, year, month, ...)` — writes a config version effective from the given month using `ON CONFLICT DO UPDATE`, per the §5.2 change rule. Past months are frozen; the current and future months read the new version.

### `internal/subscription/`

- **`model.go`** — Three types:
  - `Identity` — the stable `amplop.subscription` row (name, color; not versioned).
  - `Version` — one effective-dated snapshot in `amplop.subscription_version`.
  - `Resolved` — the flattened result of the §5.1 lateral join, consumed by the engine and the month dashboard. `Active` is omitted because the query already filters it.
- **`repo.go`** — `Repo` with:
  - `ListIdentities(ctx)` — all subscription identity rows ordered by name; used by the service to validate a `subscription_id` on a Langganan expense.
  - `ByID(ctx, id)` — fetch by PK; `apierr.NotFound` on miss.
  - `Resolve(ctx, year, month)` — the §5.1 **`JOIN LATERAL`** query that picks the latest active version per subscription with `(effective_year, effective_month) <= (year, month)`. Returns an empty slice (not an error) when no active subscriptions exist for the month. A subscription whose earliest version is after the viewed month correctly appears absent.
  - `CreateWithVersion(ctx, ...)` — inserts the identity row and its first version in a single **transaction** (two INSERTs with `RETURNING` on the identity insert).
  - `UpdateIdentity(ctx, id, name, color)` — updates cosmetic fields directly on the identity row; applies to all months with no versioning, per §5.2.
  - `UpsertVersion(ctx, subID, year, month, alloc, dueDay, active)` — handles both "edit alloc/due_day" (active=true) and "soft-delete" (active=false) by upserting a version for the current month. Past months keep their older version.

### `internal/expense/`

- **`model.go`** — `Expense` struct with all DB fields. Notable details:
  - `OccurredTime *time.Time` — nullable SQL `TIME`; `lib/pq` scans it as a `time.Time` with date `0001-01-01`.
  - `OccurredYear int16` / `OccurredMonth int16` — **generated columns** (stored by the DB from `occurred_date`); populated on `SELECT`/`RETURNING` but must never appear in an `INSERT` column list.
  - `OccurredAt() time.Time` — combines the Jakarta calendar date from `OccurredDate` with the clock-face H:M:S from `OccurredTime` into a single Asia/Jakarta `time.Time`, ready to serialize as RFC3339. Returns midnight when no time was recorded.
- **`repo.go`** — `Repo` with:
  - `ForMonth(ctx, year, month)` — the §6.2 **wide boundary window** query: `occurred_date BETWEEN (firstOfMonth−7d) AND (lastOfMonth+7d)`. This wider-than-calendar range ensures cross-boundary belanja weeks and weekends are included; the engine does the precise attribution. The window is computed from `timeutil.FirstOfMonth`/`LastOfMonth`.
  - `ByID(ctx, id)` — fetch by PK; `apierr.NotFound` on miss.
  - `Create(ctx, e)` — `INSERT` returning all columns (including the DB-generated `id`, `occurred_year`, `occurred_month`, timestamps). Generated columns are excluded from the column list.
  - `Update(ctx, e)` — `UPDATE … RETURNING` all columns; `apierr.NotFound` if no row matched.
  - `Delete(ctx, id)` — checks `RowsAffected == 0` → `apierr.NotFound`.
  - `ExistsForSubscriptionMonth(ctx, subID, year, month, excludeID)` — pre-check for the once-per-month Langganan rule: returns true if another expense already exists for the same subscription in that calendar month. `excludeID` excludes the row being updated so it doesn't conflict with itself. Two query variants (with/without exclude) avoid any type ambiguity with NULL parameters.
  - `mapUniqueErr` — converts a `lib/pq` unique-index violation on `expense_one_sub_payment_per_month` into `apierr.Conflict("subscription already paid this month")` as a **backstop** for the once-per-month rule (the service pre-check is the first line of defence; this catches any race or bypass).

---

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Tuple comparison `(year, month) <= ($1, $2)` | CockroachDB maps this to a contiguous range scan on the composite `UNIQUE` index — no separate index needed, no `year*12+month` arithmetic that would defeat the index (spec §5.1). |
| `JOIN LATERAL` for subscription resolution | Standard SQL; CockroachDB 22.x+ supports it. Picks the single latest version per subscription in one query pass. |
| `Identity` (not `Subscription`) as the type name | Avoids a name clash with `envelope.Subscription` when the Phase 3 service imports both packages. |
| `RETURNING` on Create/Update | Returns the DB-generated `id`, generated columns, and timestamps without a second round-trip. |
| Two-query approach in `ExistsForSubscriptionMonth` | Avoids passing a nullable UUID parameter to a single query, which can have type-inference issues with `lib/pq`. Clean and unambiguous. |
| Integration tests with `//go:build integration` | Excluded from `go test ./...` so normal CI never needs a DB. Run explicitly with `-tags=integration` against `devdb`. Each test inserts data with unique identifiers and defers `DELETE` for isolation. |

---

## Integration test coverage

Tests require `DB_HOST` to be set (auto-skipped otherwise). They target `devdb` with the migration from `migrations/0001_init_amplop.sql` already applied.

| Package | Scenario |
|---------|---------|
| `budget` | Baseline resolves for any month ≥ 2025-01; `NotFound` before baseline; new version at (2099,3) is frozen for (2099,2) and applies at (2099,3+); re-upsert updates in place |
| `subscription` | Subscription created at (2099,1) is absent from (2098,12); visible at (2099,1+); newer version at (2099,3) overrides from that month forward; `active=false` version hides the subscription from that month onward while keeping earlier months intact; `ByID` NotFound; `UpdateIdentity` reflected in `Resolve` |
| `expense` | Jun 29 expense appears in July's wide window but not May's; Jul 1 appears in June's window; `OccurredAt()` returns midnight Jakarta when no time, correct H:M:S when time is set; second Langganan payment for same sub+month hits the DB unique index → `apierr.Conflict`; `ExistsForSubscriptionMonth` with `excludeID` returns false for own row; Update/Delete CRUD; moving a Langganan payment into an occupied month → `apierr.Conflict` |

---

## What's next (Phase 3)

- Services with validation: Langganan/subscription_id rule, once-per-month pre-check, effective-from-current-month writes.
- `month` service: resolve config + subs → load expenses over wide window → run engine → assemble §7.1 dashboard payload.
- Handlers + route wiring for all §7 endpoints.
- Handler tests with `TIME` pinned.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QdywT2QTYzwyBAKTDFNn4K)_