### PR TITLE
feat: Amplop v2 Phase 3 — services, HTTP handlers, and routed function

### DIFF
--- a/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
+++ b/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
@@ -415,9 +415,9 @@ Each phase ends green (compiles, tests pass). TDD for the engine and the effecti
 - [x] Integration tests against local `devdb`, including: effective-dating (a change in month X is frozen for X−1 and applies X→forward; subscription created later is absent from earlier months; soft-end keeps past months) **and** the once-per-month unique partial index rejecting a duplicate Langganan payment.
 
 ### Phase 3 — Services + HTTP
-- [ ] Services with validation: expenses (Langganan/subscription_id rule **and the once-per-month payment rule** — service pre-check + graceful unique-violation handling → 409), subscriptions, budget; writing effective-from-current-month versions.
-- [ ] `month` service: resolve config + subs → load expenses over the wide window → run engine → assemble §7.1 payload (incl. derived `subscriptions[].paid` and `occurred_at`).
-- [ ] Handlers + route wiring for all §7 endpoints; **error→status mapping per §4.3**; handler tests (happy + validation 400, duplicate-payment 409, unknown-id 404) with `TIME` pinned.
+- [x] Services with validation: expenses (Langganan/subscription_id rule **and the once-per-month payment rule** — service pre-check + graceful unique-violation handling → 409), subscriptions, budget; writing effective-from-current-month versions.
+- [x] `month` service: resolve config + subs → load expenses over the wide window → run engine → assemble §7.1 payload (incl. derived `subscriptions[].paid` and `occurred_at`).
+- [x] Handlers + route wiring for all §7 endpoints; **error→status mapping per §4.3**; handler tests (happy + validation 400, duplicate-payment 409, unknown-id 404) with `TIME` pinned.
 
 ### Phase 4 — Run & deploy
 - [ ] Verify local run (Makefile target, docker-compose service).

--- a/function.go
+++ b/function.go
@@ -1,26 +1,110 @@
 // Package expensefunction registers the single routed Cloud Function "Expense".
 //
 // All v2 endpoints are served by one HTTP function through an internal
-// method+path router (spec §4.2). Domain routes are wired in Phase 3; for now
-// the router only carries shared middleware (CORS, panic recovery, JSON, and
-// the typed-error→status mapping) and a 404 fallback.
+// method+path router (spec §4.2): shared middleware (CORS, panic recovery,
+// JSON, typed-error→status mapping) plus the §7 domain routes.
 package expensefunction
 
 import (
-	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+	"net/http"
+	"sync"
 
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/ishanwardhono/expense-function/internal/budget"
+	"github.com/ishanwardhono/expense-function/internal/expense"
+	"github.com/ishanwardhono/expense-function/internal/month"
+	"github.com/ishanwardhono/expense-function/internal/platform/config"
+	"github.com/ishanwardhono/expense-function/internal/platform/database"
 	"github.com/ishanwardhono/expense-function/internal/platform/httpx"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+	"github.com/ishanwardhono/expense-function/internal/subscription"
 )
 
 func init() {
-	r := newRouter()
-	functions.HTTP("Expense", httpx.Middleware(r.ServeHTTP))
+	functions.HTTP("Expense", httpx.Middleware(newRouter().ServeHTTP))
 }
 
-// newRouter builds the application router. Routes are added here as handlers
-// land (Phase 3).
+// handlers bundles the wired HTTP handlers for the domain routes.
+type handlers struct {
+	month   *month.Handler
+	expense *expense.Handler
+	sub     *subscription.Handler
+	budget  *budget.Handler
+}
+
+// dependency provider: the DB connection is opened lazily on the first request
+// (the serverless cold-start pattern) so init() never fails on a bad
+// environment; a connect error surfaces as a 500 on the request that needed it.
+var (
+	once     sync.Once
+	cached   *handlers
+	cacheErr error
+)
+
+func getHandlers() (*handlers, error) {
+	once.Do(func() {
+		db, err := database.Connect(config.LoadDatabase())
+		if err != nil {
+			cacheErr = err
+			return
+		}
+		cached = buildHandlers(db, timeutil.Now)
+	})
+	return cached, cacheErr
+}
+
+// buildHandlers wires repos → services → handlers. Exposed-for-testing seam:
+// callers can pass a test DB and a pinned clock.
+func buildHandlers(db *sqlx.DB, now timeutil.Clock) *handlers {
+	expenseRepo := expense.NewRepo(db)
+	subRepo := subscription.NewRepo(db)
+	budgetRepo := budget.NewRepo(db)
+
+	expenseSvc := expense.NewService(expenseRepo, subRepo)
+	subSvc := subscription.NewService(subRepo, now)
+	budgetSvc := budget.NewService(budgetRepo, now)
+	monthSvc := month.NewService(budgetRepo, subRepo, expenseRepo, now)
+
+	return &handlers{
+		month:   month.NewHandler(monthSvc, now),
+		expense: expense.NewHandler(expenseSvc),
+		sub:     subscription.NewHandler(subSvc, now),
+		budget:  budget.NewHandler(budgetSvc, now),
+	}
+}
+
+// newRouter builds the application router. Each route resolves the lazily-built
+// handlers, so a DB error becomes a 500 rather than a startup crash.
 func newRouter() *httpx.Router {
 	r := httpx.NewRouter()
-	// TODO(Phase 3): r.Handle(http.MethodGet, "/month", monthHandler) etc.
+
+	r.Handle(http.MethodGet, "/month", lazy(func(h *handlers) httpx.HandlerFunc { return h.month.Get }))
+
+	r.Handle(http.MethodPost, "/expenses", lazy(func(h *handlers) httpx.HandlerFunc { return h.expense.Create }))
+	r.Handle(http.MethodPut, "/expenses/{id}", lazy(func(h *handlers) httpx.HandlerFunc { return h.expense.Update }))
+	r.Handle(http.MethodDelete, "/expenses/{id}", lazy(func(h *handlers) httpx.HandlerFunc { return h.expense.Delete }))
+
+	r.Handle(http.MethodGet, "/subscriptions", lazy(func(h *handlers) httpx.HandlerFunc { return h.sub.List }))
+	r.Handle(http.MethodPost, "/subscriptions", lazy(func(h *handlers) httpx.HandlerFunc { return h.sub.Create }))
+	r.Handle(http.MethodPut, "/subscriptions/{id}", lazy(func(h *handlers) httpx.HandlerFunc { return h.sub.Update }))
+	r.Handle(http.MethodDelete, "/subscriptions/{id}", lazy(func(h *handlers) httpx.HandlerFunc { return h.sub.Delete }))
+
+	r.Handle(http.MethodGet, "/budget", lazy(func(h *handlers) httpx.HandlerFunc { return h.budget.Get }))
+	r.Handle(http.MethodPut, "/budget", lazy(func(h *handlers) httpx.HandlerFunc { return h.budget.Put }))
+
 	return r
+}
+
+// lazy adapts a handler selector into a route handler that resolves the
+// lazily-built dependencies on each request.
+func lazy(pick func(*handlers) httpx.HandlerFunc) httpx.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		h, err := getHandlers()
+		if err != nil {
+			return err
+		}
+		return pick(h)(w, r)
+	}
 }

--- a/internal/budget/handler.go
+++ b/internal/budget/handler.go
@@ -1,0 +1,70 @@
+package budget
+
+import (
+	"net/http"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/httpx"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// Handler serves the budget config endpoints (spec §7.4).
+type Handler struct {
+	svc *Service
+	now timeutil.Clock
+}
+
+// NewHandler builds a budget Handler. now defaults to timeutil.Now when nil.
+func NewHandler(svc *Service, now timeutil.Clock) *Handler {
+	if now == nil {
+		now = timeutil.Now
+	}
+	return &Handler{svc: svc, now: now}
+}
+
+// Response is the JSON shape returned for a resolved budget config.
+type Response struct {
+	EffectiveYear  int16 `json:"effective_year"`
+	EffectiveMonth int16 `json:"effective_month"`
+	Monthly        int64 `json:"monthly"`
+	ShopWeekly     int64 `json:"shop_weekly"`
+	WeekendBudget  int64 `json:"weekend_budget"`
+}
+
+func toResponse(c Config) Response {
+	return Response{
+		EffectiveYear:  c.EffectiveYear,
+		EffectiveMonth: c.EffectiveMonth,
+		Monthly:        c.Monthly,
+		ShopWeekly:     c.ShopWeekly,
+		WeekendBudget:  c.WeekendBudget,
+	}
+}
+
+// Get handles GET /budget?year=&month= (defaults to the current month).
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) error {
+	year, month := timeutil.CurrentMonth(h.now())
+	year, month, err := httpx.QueryYearMonth(r, year, month)
+	if err != nil {
+		return err
+	}
+	cfg, err := h.svc.Resolve(r.Context(), year, month)
+	if err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusOK, toResponse(cfg))
+	return nil
+}
+
+// Put handles PUT /budget — upserts a config effective from the current month.
+func (h *Handler) Put(w http.ResponseWriter, r *http.Request) error {
+	var req UpdateRequest
+	if err := httpx.DecodeJSON(r, &req); err != nil {
+		return err
+	}
+	cfg, err := h.svc.Update(r.Context(), req)
+	if err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusOK, toResponse(cfg))
+	return nil
+}

--- a/internal/budget/service.go
+++ b/internal/budget/service.go
@@ -1,0 +1,54 @@
+package budget
+
+import (
+	"context"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// repository is the subset of the budget repo the service depends on. The
+// concrete *Repo satisfies it; tests use an in-memory fake.
+type repository interface {
+	Resolve(ctx context.Context, year, month int) (Config, error)
+	Upsert(ctx context.Context, year, month int, monthly, shopWeekly, weekendBudget int64) error
+}
+
+// Service orchestrates budget config reads and effective-dated writes.
+type Service struct {
+	repo repository
+	now  timeutil.Clock
+}
+
+// NewService builds a budget Service. now defaults to timeutil.Now when nil.
+func NewService(repo repository, now timeutil.Clock) *Service {
+	if now == nil {
+		now = timeutil.Now
+	}
+	return &Service{repo: repo, now: now}
+}
+
+// UpdateRequest is the PUT /budget body (spec §7.4).
+type UpdateRequest struct {
+	Monthly       int64 `json:"monthly"`
+	ShopWeekly    int64 `json:"shop_weekly"`
+	WeekendBudget int64 `json:"weekend_budget"`
+}
+
+// Resolve returns the effective budget config for (year, month).
+func (s *Service) Resolve(ctx context.Context, year, month int) (Config, error) {
+	return s.repo.Resolve(ctx, year, month)
+}
+
+// Update validates req and upserts a budget config version effective from the
+// current Asia/Jakarta month (spec §5.2). It returns the now-effective config.
+func (s *Service) Update(ctx context.Context, req UpdateRequest) (Config, error) {
+	if req.Monthly < 0 || req.ShopWeekly < 0 || req.WeekendBudget < 0 {
+		return Config{}, apierr.Invalid("budget values must be >= 0")
+	}
+	year, month := timeutil.CurrentMonth(s.now())
+	if err := s.repo.Upsert(ctx, year, month, req.Monthly, req.ShopWeekly, req.WeekendBudget); err != nil {
+		return Config{}, err
+	}
+	return s.repo.Resolve(ctx, year, month)
+}

--- a/internal/budget/service_test.go
+++ b/internal/budget/service_test.go
@@ -1,0 +1,126 @@
+package budget
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// fakeRepo is an in-memory budget repository keyed by (year, month).
+type fakeRepo struct {
+	rows      map[[2]int]Config
+	upsertErr error
+}
+
+func newFakeRepo() *fakeRepo { return &fakeRepo{rows: map[[2]int]Config{}} }
+
+func (f *fakeRepo) Resolve(_ context.Context, year, month int) (Config, error) {
+	// Find the greatest (y, m) <= (year, month).
+	best := [2]int{-1, -1}
+	for k := range f.rows {
+		if k[0] < year || (k[0] == year && k[1] <= month) {
+			if k[0] > best[0] || (k[0] == best[0] && k[1] > best[1]) {
+				best = k
+			}
+		}
+	}
+	if best[0] == -1 {
+		return Config{}, apierr.NotFound("no budget config for %d-%02d", year, month)
+	}
+	return f.rows[best], nil
+}
+
+func (f *fakeRepo) Upsert(_ context.Context, year, month int, monthly, shopWeekly, weekendBudget int64) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.rows[[2]int{year, month}] = Config{
+		EffectiveYear: int16(year), EffectiveMonth: int16(month),
+		Monthly: monthly, ShopWeekly: shopWeekly, WeekendBudget: weekendBudget,
+	}
+	return nil
+}
+
+func fixedClock(y, m, d int) timeutil.Clock {
+	return func() time.Time { return timeutil.Date(y, m, d) }
+}
+
+func TestUpdate_StampsCurrentMonthAndResolves(t *testing.T) {
+	repo := newFakeRepo()
+	repo.rows[[2]int{2025, 1}] = Config{EffectiveYear: 2025, EffectiveMonth: 1, Monthly: 5_000_000, ShopWeekly: 600_000, WeekendBudget: 200_000}
+	svc := NewService(repo, fixedClock(2026, 6, 23))
+
+	cfg, err := svc.Update(context.Background(), UpdateRequest{Monthly: 7_000_000, ShopWeekly: 700_000, WeekendBudget: 250_000})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if cfg.EffectiveYear != 2026 || cfg.EffectiveMonth != 6 {
+		t.Errorf("effective month: got %d-%d, want 2026-6", cfg.EffectiveYear, cfg.EffectiveMonth)
+	}
+	if cfg.Monthly != 7_000_000 {
+		t.Errorf("monthly: got %d, want 7000000", cfg.Monthly)
+	}
+
+	// A past month still resolves to the 2025-01 baseline (frozen).
+	past, err := svc.Resolve(context.Background(), 2026, 5)
+	if err != nil {
+		t.Fatalf("Resolve past: %v", err)
+	}
+	if past.Monthly != 5_000_000 {
+		t.Errorf("past monthly: got %d, want 5000000 (frozen)", past.Monthly)
+	}
+}
+
+func TestUpdate_NegativeRejected(t *testing.T) {
+	svc := NewService(newFakeRepo(), fixedClock(2026, 6, 23))
+	_, err := svc.Update(context.Background(), UpdateRequest{Monthly: -1})
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindInvalid {
+		t.Fatalf("expected Invalid, got %v", err)
+	}
+}
+
+func TestHandler_Put_BadJSON(t *testing.T) {
+	h := NewHandler(NewService(newFakeRepo(), fixedClock(2026, 6, 23)), fixedClock(2026, 6, 23))
+	req := httptest.NewRequest(http.MethodPut, "/budget", strings.NewReader("{not json"))
+	err := h.Put(httptest.NewRecorder(), req)
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindInvalid {
+		t.Fatalf("expected Invalid, got %v", err)
+	}
+}
+
+func TestHandler_Get_DefaultsToCurrentMonth(t *testing.T) {
+	repo := newFakeRepo()
+	repo.rows[[2]int{2025, 1}] = Config{EffectiveYear: 2025, EffectiveMonth: 1, Monthly: 5_000_000}
+	h := NewHandler(NewService(repo, fixedClock(2026, 6, 23)), fixedClock(2026, 6, 23))
+
+	req := httptest.NewRequest(http.MethodGet, "/budget", nil)
+	rec := httptest.NewRecorder()
+	if err := h.Get(rec, req); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"monthly":5000000`) {
+		t.Errorf("body missing monthly: %s", rec.Body.String())
+	}
+}
+
+func TestHandler_Get_BadMonth(t *testing.T) {
+	h := NewHandler(NewService(newFakeRepo(), fixedClock(2026, 6, 23)), fixedClock(2026, 6, 23))
+	req := httptest.NewRequest(http.MethodGet, "/budget?month=13", nil)
+	err := h.Get(httptest.NewRecorder(), req)
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindInvalid {
+		t.Fatalf("expected Invalid, got %v", err)
+	}
+}

--- a/internal/envelope/rules.go
+++ b/internal/envelope/rules.go
@@ -47,6 +47,22 @@ func (e EnvelopeID) Label() string {
 	return string(e)
 }
 
+// ShortLabel returns the compact badge label used on per-expense rows in the
+// day list (spec §7.1, e.g. "BLNJ", "SUBS").
+func (e EnvelopeID) ShortLabel() string {
+	switch e {
+	case EnvBelanja:
+		return "BLNJ"
+	case EnvWeekend:
+		return "WKND"
+	case EnvLangganan:
+		return "SUBS"
+	case EnvFleksibel:
+		return "FLEX"
+	}
+	return string(e)
+}
+
 // isWeekend reports whether the date falls on Saturday or Sunday (Asia/Jakarta).
 // Normalizing to Loc keeps weekday classification consistent with dayNum's
 // date comparison even if a caller passes a timestamp in another zone.

--- a/internal/expense/handler.go
+++ b/internal/expense/handler.go
@@ -1,0 +1,105 @@
+package expense
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/ishanwardhono/expense-function/internal/envelope"
+	"github.com/ishanwardhono/expense-function/internal/platform/httpx"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// EnvelopeRef is the derived envelope badge on an expense row (spec §7.1).
+type EnvelopeRef struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// Response is the JSON shape of one expense row (spec §7.1/§7.2). It is reused
+// by the month dashboard's day list.
+type Response struct {
+	ID             string      `json:"id"`
+	Date           string      `json:"date"`        // YYYY-MM-DD (day-group key)
+	OccurredAt     string      `json:"occurred_at"` // RFC3339 (Asia/Jakarta offset)
+	Amount         int64       `json:"amount"`
+	Category       string      `json:"category"`
+	SubscriptionID *string     `json:"subscription_id"`
+	Note           string      `json:"note"`
+	Envelope       EnvelopeRef `json:"envelope"`
+}
+
+// ToResponse maps a DB expense to its API representation, deriving the envelope
+// from category + date (spec §6.1).
+func ToResponse(e Expense) Response {
+	env := envelope.EnvelopeOf(envelope.Category(e.Category), e.OccurredDate)
+	var subID *string
+	if e.SubscriptionID != nil {
+		s := e.SubscriptionID.String()
+		subID = &s
+	}
+	return Response{
+		ID:             e.ID.String(),
+		Date:           e.OccurredDate.In(timeutil.Loc).Format("2006-01-02"),
+		OccurredAt:     e.OccurredAt().Format(time.RFC3339),
+		Amount:         e.Amount,
+		Category:       e.Category,
+		SubscriptionID: subID,
+		Note:           e.Note,
+		Envelope:       EnvelopeRef{ID: string(env), Label: env.ShortLabel()},
+	}
+}
+
+// Handler serves the expense endpoints (spec §7.2).
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler builds an expense Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// Create handles POST /expenses.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) error {
+	var req WriteRequest
+	if err := httpx.DecodeJSON(r, &req); err != nil {
+		return err
+	}
+	e, err := h.svc.Create(r.Context(), req)
+	if err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusCreated, ToResponse(e))
+	return nil
+}
+
+// Update handles PUT /expenses/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) error {
+	id, err := httpx.PathUUID(r, "id")
+	if err != nil {
+		return err
+	}
+	var req WriteRequest
+	if err := httpx.DecodeJSON(r, &req); err != nil {
+		return err
+	}
+	e, err := h.svc.Update(r.Context(), id, req)
+	if err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusOK, ToResponse(e))
+	return nil
+}
+
+// Delete handles DELETE /expenses/{id} → 204.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) error {
+	id, err := httpx.PathUUID(r, "id")
+	if err != nil {
+		return err
+	}
+	if err := h.svc.Delete(r.Context(), id); err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusNoContent, nil)
+	return nil
+}

--- a/internal/expense/service.go
+++ b/internal/expense/service.go
@@ -1,0 +1,162 @@
+package expense
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ishanwardhono/expense-function/internal/envelope"
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// repository is the subset of the expense repo the service depends on. The
+// concrete *Repo satisfies it; tests use an in-memory fake.
+type repository interface {
+	ByID(ctx context.Context, id uuid.UUID) (Expense, error)
+	Create(ctx context.Context, e Expense) (Expense, error)
+	Update(ctx context.Context, e Expense) (Expense, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	ExistsForSubscriptionMonth(ctx context.Context, subscriptionID uuid.UUID, year, month int, excludeID *uuid.UUID) (bool, error)
+}
+
+// subChecker verifies a referenced subscription exists (spec §7.5). The
+// subscription repo's Exists method satisfies it.
+type subChecker interface {
+	Exists(ctx context.Context, id uuid.UUID) (bool, error)
+}
+
+// Service orchestrates expense CRUD with validation, the Langganan ⇔
+// subscription_id rule, and the once-per-month payment rule (spec §7.2/§7.5).
+type Service struct {
+	repo repository
+	subs subChecker
+}
+
+// NewService builds an expense Service.
+func NewService(repo repository, subs subChecker) *Service {
+	return &Service{repo: repo, subs: subs}
+}
+
+// WriteRequest is the POST/PUT /expenses body (spec §7.2).
+type WriteRequest struct {
+	Date           string  `json:"date"` // YYYY-MM-DD
+	Time           *string `json:"time"` // HH:MM, optional
+	Amount         int64   `json:"amount"`
+	Category       string  `json:"category"`
+	SubscriptionID *string `json:"subscription_id"` // required iff category == Langganan
+	Note           string  `json:"note"`
+}
+
+var validCategories = map[envelope.Category]bool{
+	envelope.CatMakan:     true,
+	envelope.CatBelanja:   true,
+	envelope.CatJajan:     true,
+	envelope.CatCash:      true,
+	envelope.CatLainnya:   true,
+	envelope.CatLangganan: true,
+}
+
+// Create validates req and inserts a new expense.
+func (s *Service) Create(ctx context.Context, req WriteRequest) (Expense, error) {
+	e, err := s.validateAndBuild(ctx, req, nil)
+	if err != nil {
+		return Expense{}, err
+	}
+	return s.repo.Create(ctx, e)
+}
+
+// Update validates req and replaces the expense with id. The once-per-month
+// check excludes the row itself so re-saving an unchanged Langganan payment is
+// allowed (spec §7.2).
+func (s *Service) Update(ctx context.Context, id uuid.UUID, req WriteRequest) (Expense, error) {
+	if _, err := s.repo.ByID(ctx, id); err != nil {
+		return Expense{}, err
+	}
+	e, err := s.validateAndBuild(ctx, req, &id)
+	if err != nil {
+		return Expense{}, err
+	}
+	e.ID = id
+	return s.repo.Update(ctx, e)
+}
+
+// Delete removes the expense with id.
+func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
+	return s.repo.Delete(ctx, id)
+}
+
+// validateAndBuild performs §7.5 validation and assembles the DB model.
+// excludeID is the row being edited (nil on create), excluded from the
+// once-per-month pre-check.
+func (s *Service) validateAndBuild(ctx context.Context, req WriteRequest, excludeID *uuid.UUID) (Expense, error) {
+	if req.Amount <= 0 {
+		return Expense{}, apierr.Invalid("amount must be > 0")
+	}
+	cat := envelope.Category(req.Category)
+	if !validCategories[cat] {
+		return Expense{}, apierr.Invalid("invalid category %q", req.Category)
+	}
+	date, err := timeutil.ParseDate(req.Date)
+	if err != nil {
+		return Expense{}, apierr.Invalid("invalid date %q, expected YYYY-MM-DD", req.Date)
+	}
+	var occurredTime *time.Time
+	if req.Time != nil && *req.Time != "" {
+		occurredTime, err = parseTimeOfDay(*req.Time)
+		if err != nil {
+			return Expense{}, err
+		}
+	}
+
+	var subID *uuid.UUID
+	if cat == envelope.CatLangganan {
+		if req.SubscriptionID == nil || *req.SubscriptionID == "" {
+			return Expense{}, apierr.Invalid("subscription_id is required for Langganan expenses")
+		}
+		parsed, err := uuid.Parse(*req.SubscriptionID)
+		if err != nil {
+			return Expense{}, apierr.Invalid("invalid subscription_id %q", *req.SubscriptionID)
+		}
+		exists, err := s.subs.Exists(ctx, parsed)
+		if err != nil {
+			return Expense{}, err
+		}
+		if !exists {
+			return Expense{}, apierr.Invalid("subscription %s not found", parsed)
+		}
+		// Once-per-month pre-check on the calendar month of the date.
+		year, month := date.Year(), int(date.Month())
+		dup, err := s.repo.ExistsForSubscriptionMonth(ctx, parsed, year, month, excludeID)
+		if err != nil {
+			return Expense{}, err
+		}
+		if dup {
+			return Expense{}, apierr.Conflict("subscription already paid this month")
+		}
+		subID = &parsed
+	} else if req.SubscriptionID != nil && *req.SubscriptionID != "" {
+		return Expense{}, apierr.Invalid("subscription_id is only valid for Langganan expenses")
+	}
+
+	return Expense{
+		OccurredDate:   date,
+		OccurredTime:   occurredTime,
+		Amount:         req.Amount,
+		Category:       string(cat),
+		SubscriptionID: subID,
+		Note:           req.Note,
+	}, nil
+}
+
+// parseTimeOfDay parses "HH:MM" into the clock-face-hours-in-UTC representation
+// the DB stores as SQL TIME (matches Expense.OccurredAt — model.go).
+func parseTimeOfDay(s string) (*time.Time, error) {
+	t, err := time.Parse("15:04", s)
+	if err != nil {
+		return nil, apierr.Invalid("invalid time %q, expected HH:MM", s)
+	}
+	tt := time.Date(1, 1, 1, t.Hour(), t.Minute(), 0, 0, time.UTC)
+	return &tt, nil
+}

--- a/internal/expense/service_test.go
+++ b/internal/expense/service_test.go
@@ -1,0 +1,235 @@
+package expense
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+	"github.com/ishanwardhono/expense-function/internal/platform/httpx"
+)
+
+// fakeRepo is an in-memory expense repository.
+type fakeRepo struct {
+	byID map[uuid.UUID]Expense
+}
+
+func newFakeRepo() *fakeRepo { return &fakeRepo{byID: map[uuid.UUID]Expense{}} }
+
+func (f *fakeRepo) ByID(_ context.Context, id uuid.UUID) (Expense, error) {
+	e, ok := f.byID[id]
+	if !ok {
+		return Expense{}, apierr.NotFound("expense %s not found", id)
+	}
+	return e, nil
+}
+
+func (f *fakeRepo) Create(_ context.Context, e Expense) (Expense, error) {
+	e.ID = uuid.New()
+	e.OccurredYear = int16(e.OccurredDate.Year())
+	e.OccurredMonth = int16(e.OccurredDate.Month())
+	f.byID[e.ID] = e
+	return e, nil
+}
+
+func (f *fakeRepo) Update(_ context.Context, e Expense) (Expense, error) {
+	if _, ok := f.byID[e.ID]; !ok {
+		return Expense{}, apierr.NotFound("expense %s not found", e.ID)
+	}
+	e.OccurredYear = int16(e.OccurredDate.Year())
+	e.OccurredMonth = int16(e.OccurredDate.Month())
+	f.byID[e.ID] = e
+	return e, nil
+}
+
+func (f *fakeRepo) Delete(_ context.Context, id uuid.UUID) error {
+	if _, ok := f.byID[id]; !ok {
+		return apierr.NotFound("expense %s not found", id)
+	}
+	delete(f.byID, id)
+	return nil
+}
+
+func (f *fakeRepo) ExistsForSubscriptionMonth(_ context.Context, subID uuid.UUID, year, month int, excludeID *uuid.UUID) (bool, error) {
+	for id, e := range f.byID {
+		if excludeID != nil && id == *excludeID {
+			continue
+		}
+		if e.SubscriptionID != nil && *e.SubscriptionID == subID &&
+			int(e.OccurredYear) == year && int(e.OccurredMonth) == month {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type fakeSubs struct{ exists map[uuid.UUID]bool }
+
+func (f fakeSubs) Exists(_ context.Context, id uuid.UUID) (bool, error) {
+	return f.exists[id], nil
+}
+
+func newService(repo *fakeRepo, subIDs ...uuid.UUID) *Service {
+	m := map[uuid.UUID]bool{}
+	for _, id := range subIDs {
+		m[id] = true
+	}
+	return NewService(repo, fakeSubs{exists: m})
+}
+
+func TestCreate_Validation(t *testing.T) {
+	subID := uuid.New()
+	svc := newService(newFakeRepo(), subID)
+	subStr := subID.String()
+	other := uuid.New().String()
+	bad := "12:99"
+
+	cases := map[string]WriteRequest{
+		"zero amount":        {Date: "2026-06-15", Amount: 0, Category: "Makan"},
+		"bad category":       {Date: "2026-06-15", Amount: 1000, Category: "Nope"},
+		"bad date":           {Date: "15-06-2026", Amount: 1000, Category: "Makan"},
+		"bad time":           {Date: "2026-06-15", Amount: 1000, Category: "Makan", Time: &bad},
+		"langganan no sub":   {Date: "2026-06-15", Amount: 1000, Category: "Langganan"},
+		"non-langg with sub": {Date: "2026-06-15", Amount: 1000, Category: "Makan", SubscriptionID: &subStr},
+		"unknown sub":        {Date: "2026-06-15", Amount: 1000, Category: "Langganan", SubscriptionID: &other},
+	}
+	for name, req := range cases {
+		_, err := svc.Create(context.Background(), req)
+		var ae *apierr.Error
+		if !errors.As(err, &ae) || ae.Kind != apierr.KindInvalid {
+			t.Errorf("%s: expected Invalid, got %v", name, err)
+		}
+	}
+}
+
+func TestCreate_HappyNonLangganan(t *testing.T) {
+	repo := newFakeRepo()
+	svc := newService(repo)
+	tm := "12:10"
+	e, err := svc.Create(context.Background(), WriteRequest{
+		Date: "2026-06-15", Time: &tm, Amount: 18_000, Category: "Makan", Note: "nasi padang",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if e.ID == (uuid.UUID{}) {
+		t.Error("expected non-zero ID")
+	}
+	at := e.OccurredAt()
+	if at.Hour() != 12 || at.Minute() != 10 {
+		t.Errorf("occurred_at time: got %v, want 12:10", at)
+	}
+}
+
+func TestCreate_LanggananOncePerMonthConflict(t *testing.T) {
+	repo := newFakeRepo()
+	subID := uuid.New()
+	svc := newService(repo, subID)
+	subStr := subID.String()
+
+	first := WriteRequest{Date: "2026-06-05", Amount: 186_000, Category: "Langganan", SubscriptionID: &subStr}
+	if _, err := svc.Create(context.Background(), first); err != nil {
+		t.Fatalf("first Langganan: %v", err)
+	}
+	// Second payment, same sub + month → 409.
+	_, err := svc.Create(context.Background(), WriteRequest{
+		Date: "2026-06-20", Amount: 186_000, Category: "Langganan", SubscriptionID: &subStr,
+	})
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindConflict {
+		t.Fatalf("expected Conflict, got %v", err)
+	}
+	// A different month is allowed.
+	if _, err := svc.Create(context.Background(), WriteRequest{
+		Date: "2026-07-05", Amount: 186_000, Category: "Langganan", SubscriptionID: &subStr,
+	}); err != nil {
+		t.Errorf("July payment should succeed, got %v", err)
+	}
+}
+
+func TestUpdate_ExcludesSelfForOncePerMonth(t *testing.T) {
+	repo := newFakeRepo()
+	subID := uuid.New()
+	svc := newService(repo, subID)
+	subStr := subID.String()
+
+	e, err := svc.Create(context.Background(), WriteRequest{
+		Date: "2026-06-05", Amount: 186_000, Category: "Langganan", SubscriptionID: &subStr,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Re-saving the same row (amount changed) must not conflict with itself.
+	updated, err := svc.Update(context.Background(), e.ID, WriteRequest{
+		Date: "2026-06-05", Amount: 190_000, Category: "Langganan", SubscriptionID: &subStr,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Amount != 190_000 {
+		t.Errorf("amount: got %d, want 190000", updated.Amount)
+	}
+}
+
+func TestUpdate_UnknownID(t *testing.T) {
+	svc := newService(newFakeRepo())
+	_, err := svc.Update(context.Background(), uuid.New(), WriteRequest{
+		Date: "2026-06-05", Amount: 1000, Category: "Makan",
+	})
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestDelete_UnknownID(t *testing.T) {
+	svc := newService(newFakeRepo())
+	err := svc.Delete(context.Background(), uuid.New())
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestHandler_Create_OK(t *testing.T) {
+	h := NewHandler(newService(newFakeRepo()))
+	body := `{"date":"2026-06-15","amount":18000,"category":"Makan","note":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "/expenses", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	if err := h.Create(rec, req); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d, want 201", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"envelope":{"id":"belanja","label":"BLNJ"}`) {
+		t.Errorf("body missing envelope badge: %s", rec.Body.String())
+	}
+}
+
+func TestHandler_Create_BadJSON(t *testing.T) {
+	h := NewHandler(newService(newFakeRepo()))
+	req := httptest.NewRequest(http.MethodPost, "/expenses", strings.NewReader("{bad"))
+	err := h.Create(httptest.NewRecorder(), req)
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindInvalid {
+		t.Fatalf("expected Invalid, got %v", err)
+	}
+}
+
+func TestHandler_Delete_UnknownID_RoutedNotFound(t *testing.T) {
+	h := NewHandler(newService(newFakeRepo()))
+	rt := httpx.NewRouter()
+	rt.Handle(http.MethodDelete, "/expenses/{id}", h.Delete)
+	req := httptest.NewRequest(http.MethodDelete, "/expenses/"+uuid.New().String(), nil)
+	err := rt.ServeHTTP(httptest.NewRecorder(), req)
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}

--- a/internal/month/handler.go
+++ b/internal/month/handler.go
@@ -1,0 +1,37 @@
+package month
+
+import (
+	"net/http"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/httpx"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// Handler serves GET /month (spec §7.1).
+type Handler struct {
+	svc *Service
+	now timeutil.Clock
+}
+
+// NewHandler builds a month Handler. now defaults to timeutil.Now when nil.
+func NewHandler(svc *Service, now timeutil.Clock) *Handler {
+	if now == nil {
+		now = timeutil.Now
+	}
+	return &Handler{svc: svc, now: now}
+}
+
+// Get handles GET /month?year=&month= (defaults to the current month).
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) error {
+	year, month := timeutil.CurrentMonth(h.now())
+	year, month, err := httpx.QueryYearMonth(r, year, month)
+	if err != nil {
+		return err
+	}
+	dash, err := h.svc.Dashboard(r.Context(), year, month)
+	if err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusOK, dash)
+	return nil
+}

--- a/internal/month/model.go
+++ b/internal/month/model.go
@@ -1,0 +1,100 @@
+// Package month assembles the GET /month dashboard: it resolves the effective
+// budget config + subscription set, loads the wide-window expenses, runs the
+// pure envelope engine, and shapes the §7.1 payload.
+package month
+
+import "github.com/ishanwardhono/expense-function/internal/expense"
+
+// Dashboard is the full GET /month payload (spec §7.1).
+type Dashboard struct {
+	Period        Period                        `json:"period"`
+	Stats         Stats                         `json:"stats"`
+	Envelopes     []EnvelopeRow                 `json:"envelopes"`
+	BelanjaWeeks  []WeekDTO                     `json:"belanja_weeks"`
+	Weekends      []WeekendDTO                  `json:"weekends"`
+	Flex          Flex                          `json:"flex"`
+	Calendar      []CalendarDay                 `json:"calendar"`
+	Days          map[string][]expense.Response `json:"days"`
+	Subscriptions []SubscriptionDTO             `json:"subscriptions"`
+}
+
+// Period identifies the viewed month.
+type Period struct {
+	Year      int    `json:"year"`
+	Month     int    `json:"month"`
+	Label     string `json:"label"` // e.g. "Juni 2026"
+	IsCurrent bool   `json:"is_current"`
+}
+
+// Stats is the month-level total.
+type Stats struct {
+	Spent     int64 `json:"spent"`
+	Budget    int64 `json:"budget"`
+	Remaining int64 `json:"remaining"`
+}
+
+// EnvelopeRow is one of the four envelope summary rows.
+type EnvelopeRow struct {
+	ID     string `json:"id"`
+	Label  string `json:"label"`
+	Budget int64  `json:"budget"`
+	Spent  int64  `json:"spent"`
+	Left   int64  `json:"left"`
+	Over   bool   `json:"over"`
+}
+
+// WeekDTO is one shopping week (Mon–Sun, owned by its Friday).
+type WeekDTO struct {
+	Range  string `json:"range"` // e.g. "1–7 Jun"
+	Monday string `json:"monday"`
+	Friday string `json:"friday"`
+	Sunday string `json:"sunday"`
+	Budget int64  `json:"budget"`
+	Spent  int64  `json:"spent"`
+	Left   int64  `json:"left"`
+	State  string `json:"state"`
+}
+
+// WeekendDTO is one weekend (Sat–Sun, owned by its Saturday).
+type WeekendDTO struct {
+	Range    string `json:"range"`
+	Saturday string `json:"saturday"`
+	Sunday   string `json:"sunday"`
+	Budget   int64  `json:"budget"`
+	Spent    int64  `json:"spent"`
+	Left     int64  `json:"left"`
+	State    string `json:"state"`
+}
+
+// Flex is the flexible-envelope summary.
+type Flex struct {
+	Budget int64 `json:"budget"`
+	Spent  int64 `json:"spent"`
+	Left   int64 `json:"left"`
+}
+
+// CalendarDay is one cell of the month calendar grid.
+type CalendarDay struct {
+	Date      string `json:"date"`
+	Dow       int    `json:"dow"` // ISO weekday: Monday=1 .. Sunday=7
+	IsWeekend bool   `json:"is_weekend"`
+	IsToday   bool   `json:"is_today"`
+	Spent     int64  `json:"spent"`
+}
+
+// PaidDTO is the derived payment of a subscription this month (nil when unpaid).
+type PaidDTO struct {
+	Date   string `json:"date"`
+	Amount int64  `json:"amount"`
+}
+
+// SubscriptionDTO is one resolved subscription with its derived payment status.
+type SubscriptionDTO struct {
+	ID     string   `json:"id"`
+	Name   string   `json:"name"`
+	Color  string   `json:"color"`
+	Alloc  int64    `json:"alloc"`
+	DueDay int16    `json:"due_day"`
+	Paid   *PaidDTO `json:"paid"`
+	Status string   `json:"status"`
+}

--- a/internal/month/service.go
+++ b/internal/month/service.go
@@ -1,0 +1,193 @@
+package month
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ishanwardhono/expense-function/internal/budget"
+	"github.com/ishanwardhono/expense-function/internal/envelope"
+	"github.com/ishanwardhono/expense-function/internal/expense"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+	"github.com/ishanwardhono/expense-function/internal/subscription"
+)
+
+// budgetResolver resolves the effective budget config for a month (spec §5.1).
+type budgetResolver interface {
+	Resolve(ctx context.Context, year, month int) (budget.Config, error)
+}
+
+// subResolver resolves the active subscription set for a month (spec §5.1).
+type subResolver interface {
+	Resolve(ctx context.Context, year, month int) ([]subscription.Resolved, error)
+}
+
+// expenseLister loads expenses over the wide boundary window (spec §6.2).
+type expenseLister interface {
+	ForMonth(ctx context.Context, year, month int) ([]expense.Expense, error)
+}
+
+// Service resolves the month context and assembles the dashboard payload.
+type Service struct {
+	budget   budgetResolver
+	subs     subResolver
+	expenses expenseLister
+	now      timeutil.Clock
+}
+
+// NewService builds a month Service. now defaults to timeutil.Now when nil.
+func NewService(b budgetResolver, s subResolver, e expenseLister, now timeutil.Clock) *Service {
+	if now == nil {
+		now = timeutil.Now
+	}
+	return &Service{budget: b, subs: s, expenses: e, now: now}
+}
+
+// Dashboard resolves the effective context for (year, month), runs the engine,
+// and assembles the §7.1 payload.
+func (s *Service) Dashboard(ctx context.Context, year, month int) (Dashboard, error) {
+	cfg, err := s.budget.Resolve(ctx, year, month)
+	if err != nil {
+		return Dashboard{}, err
+	}
+	resolvedSubs, err := s.subs.Resolve(ctx, year, month)
+	if err != nil {
+		return Dashboard{}, err
+	}
+	exps, err := s.expenses.ForMonth(ctx, year, month)
+	if err != nil {
+		return Dashboard{}, err
+	}
+
+	today := s.now()
+
+	engSubs := make([]envelope.Subscription, 0, len(resolvedSubs))
+	for _, r := range resolvedSubs {
+		engSubs = append(engSubs, envelope.Subscription{
+			ID: r.ID.String(), Name: r.Name, Color: r.Color, Alloc: r.Alloc, DueDay: int(r.DueDay),
+		})
+	}
+	engExps := make([]envelope.Expense, 0, len(exps))
+	for _, e := range exps {
+		subID := ""
+		if e.SubscriptionID != nil {
+			subID = e.SubscriptionID.String()
+		}
+		engExps = append(engExps, envelope.Expense{
+			Date: e.OccurredDate, Amount: e.Amount, Category: envelope.Category(e.Category), SubscriptionID: subID,
+		})
+	}
+
+	result := envelope.ComputeMonth(envelope.MonthInput{
+		Year:  year,
+		Month: month,
+		Today: today,
+		Config: envelope.Config{
+			Monthly: cfg.Monthly, ShopWeekly: cfg.ShopWeekly, WeekendBudget: cfg.WeekendBudget,
+		},
+		Subscriptions: engSubs,
+		Expenses:      engExps,
+	})
+
+	curY, curM := timeutil.CurrentMonth(today)
+
+	dash := Dashboard{
+		Period: Period{
+			Year: year, Month: month,
+			Label:     fmt.Sprintf("%s %d", timeutil.MonthName(month), year),
+			IsCurrent: year == curY && month == curM,
+		},
+		Stats: Stats{Spent: result.TotalSpent, Budget: cfg.Monthly, Remaining: result.Sisa},
+		Flex:  Flex{Budget: result.FlexBudget, Spent: result.FlexSpent, Left: result.FlexBudget - result.FlexSpent},
+		Days:  map[string][]expense.Response{},
+	}
+
+	for _, row := range result.Rows {
+		dash.Envelopes = append(dash.Envelopes, EnvelopeRow{
+			ID: string(row.ID), Label: row.Label, Budget: row.Budget, Spent: row.Spent, Left: row.Left, Over: row.Over,
+		})
+	}
+	for _, w := range result.Weeks {
+		dash.BelanjaWeeks = append(dash.BelanjaWeeks, WeekDTO{
+			Range:  rangeLabel(w.Monday, w.Sunday),
+			Monday: ymd(w.Monday), Friday: ymd(w.Friday), Sunday: ymd(w.Sunday),
+			Budget: w.Budget, Spent: w.Spent, Left: w.Left, State: string(w.State),
+		})
+	}
+	for _, w := range result.Weekends {
+		dash.Weekends = append(dash.Weekends, WeekendDTO{
+			Range:    rangeLabel(w.Saturday, w.Sunday),
+			Saturday: ymd(w.Saturday), Sunday: ymd(w.Sunday),
+			Budget: w.Budget, Spent: w.Spent, Left: w.Left, State: string(w.State),
+		})
+	}
+
+	// Calendar grid: one cell per day of the calendar month.
+	last := timeutil.LastOfMonth(year, month).Day()
+	for d := 1; d <= last; d++ {
+		date := timeutil.Date(year, month, d)
+		dash.Calendar = append(dash.Calendar, CalendarDay{
+			Date:      ymd(date),
+			Dow:       isoDow(date),
+			IsWeekend: isWeekend(date),
+			IsToday:   timeutil.SameDate(date, today),
+			Spent:     envelope.SpentOf(engExps, date),
+		})
+	}
+
+	// Day list: in-month expenses grouped by calendar date, preserving repo order.
+	for _, e := range exps {
+		ed := e.OccurredDate.In(timeutil.Loc)
+		if ed.Year() != year || int(ed.Month()) != month {
+			continue
+		}
+		key := ymd(e.OccurredDate)
+		dash.Days[key] = append(dash.Days[key], expense.ToResponse(e))
+	}
+
+	// Subscriptions with derived payment status.
+	for _, sub := range engSubs {
+		status := envelope.SubscriptionStatus(sub, engExps, year, month)
+		dto := SubscriptionDTO{
+			ID: sub.ID, Name: sub.Name, Color: sub.Color, Alloc: sub.Alloc, DueDay: int16(sub.DueDay),
+			Status: string(status.Status),
+		}
+		if status.Paid {
+			dto.Paid = &PaidDTO{Date: ymd(status.PaidDate), Amount: status.PaidAmount}
+		}
+		dash.Subscriptions = append(dash.Subscriptions, dto)
+	}
+
+	return dash, nil
+}
+
+// ymd formats a date as YYYY-MM-DD in Asia/Jakarta.
+func ymd(t time.Time) string {
+	return t.In(timeutil.Loc).Format("2006-01-02")
+}
+
+// isoDow returns the ISO weekday (Monday=1 .. Sunday=7).
+func isoDow(t time.Time) int {
+	wd := int(t.In(timeutil.Loc).Weekday()) // Sunday=0 .. Saturday=6
+	if wd == 0 {
+		return 7
+	}
+	return wd
+}
+
+// isWeekend reports whether the date is Saturday or Sunday (Asia/Jakarta).
+func isWeekend(t time.Time) bool {
+	wd := t.In(timeutil.Loc).Weekday()
+	return wd == time.Saturday || wd == time.Sunday
+}
+
+// rangeLabel renders a date range like "1–7 Jun" (same month) or "29 Jun–5 Jul"
+// (spanning two months), using Indonesian month abbreviations.
+func rangeLabel(start, end time.Time) string {
+	s := start.In(timeutil.Loc)
+	e := end.In(timeutil.Loc)
+	if s.Month() == e.Month() {
+		return fmt.Sprintf("%d–%d %s", s.Day(), e.Day(), timeutil.MonthAbbr(int(s.Month())))
+	}
+	return fmt.Sprintf("%d %s–%d %s", s.Day(), timeutil.MonthAbbr(int(s.Month())), e.Day(), timeutil.MonthAbbr(int(e.Month())))
+}

--- a/internal/month/service_test.go
+++ b/internal/month/service_test.go
@@ -1,0 +1,142 @@
+package month
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ishanwardhono/expense-function/internal/budget"
+	"github.com/ishanwardhono/expense-function/internal/expense"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+	"github.com/ishanwardhono/expense-function/internal/subscription"
+)
+
+type fakeBudget struct{ cfg budget.Config }
+
+func (f fakeBudget) Resolve(_ context.Context, _, _ int) (budget.Config, error) { return f.cfg, nil }
+
+type fakeSubs struct{ subs []subscription.Resolved }
+
+func (f fakeSubs) Resolve(_ context.Context, _, _ int) ([]subscription.Resolved, error) {
+	return f.subs, nil
+}
+
+type fakeExpenses struct{ exps []expense.Expense }
+
+func (f fakeExpenses) ForMonth(_ context.Context, _, _ int) ([]expense.Expense, error) {
+	return f.exps, nil
+}
+
+func fixedClock(y, m, d int) timeutil.Clock {
+	return func() time.Time { return timeutil.Date(y, m, d) }
+}
+
+func exp(date time.Time, amount int64, cat string, sub *uuid.UUID) expense.Expense {
+	return expense.Expense{
+		ID:             uuid.New(),
+		OccurredDate:   date,
+		Amount:         amount,
+		Category:       cat,
+		SubscriptionID: sub,
+	}
+}
+
+func TestDashboard_Assembly(t *testing.T) {
+	subID := uuid.New()
+	cfg := budget.Config{Monthly: 5_000_000, ShopWeekly: 600_000, WeekendBudget: 200_000}
+	subs := []subscription.Resolved{{ID: subID, Name: "Netflix", Color: "#c8403c", Alloc: 187_000, DueDay: 5}}
+	exps := []expense.Expense{
+		exp(timeutil.Date(2026, 6, 15), 18_000, "Makan", nil),        // weekday → belanja, June week
+		exp(timeutil.Date(2026, 6, 5), 186_000, "Langganan", &subID), // langganan, paid
+		exp(timeutil.Date(2026, 6, 16), 8_000, "Lainnya", nil),       // weekday → fleksibel
+		exp(timeutil.Date(2026, 6, 29), 50_000, "Belanja", nil),      // week owned by July's Friday
+	}
+
+	svc := NewService(fakeBudget{cfg}, fakeSubs{subs}, fakeExpenses{exps}, fixedClock(2026, 6, 23))
+	dash, err := svc.Dashboard(context.Background(), 2026, 6)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+
+	if dash.Period.Label != "Juni 2026" {
+		t.Errorf("label: got %q, want %q", dash.Period.Label, "Juni 2026")
+	}
+	if !dash.Period.IsCurrent {
+		t.Error("expected is_current true for the clock's month")
+	}
+	if dash.Stats.Budget != 5_000_000 {
+		t.Errorf("stats.budget: got %d, want 5000000", dash.Stats.Budget)
+	}
+
+	// Langganan envelope spent == the single payment.
+	var langg EnvelopeRow
+	for _, r := range dash.Envelopes {
+		if r.ID == "langganan" {
+			langg = r
+		}
+	}
+	if langg.Spent != 186_000 {
+		t.Errorf("langganan spent: got %d, want 186000", langg.Spent)
+	}
+	if langg.Budget != 187_000 {
+		t.Errorf("langganan budget (subsAlloc): got %d, want 187000", langg.Budget)
+	}
+
+	// The Jun-29 belanja belongs to July's week → excluded from June week spend.
+	var shopSpent int64
+	for _, w := range dash.BelanjaWeeks {
+		shopSpent += w.Spent
+	}
+	if shopSpent != 18_000 {
+		t.Errorf("June belanja-week spend: got %d, want 18000 (Jun-29 belongs to July)", shopSpent)
+	}
+
+	// ...but it is still visible in the June day list.
+	if len(dash.Days["2026-06-29"]) != 1 {
+		t.Errorf("expected Jun-29 expense visible in days, got %d", len(dash.Days["2026-06-29"]))
+	}
+
+	// Flex spent.
+	if dash.Flex.Spent != 8_000 {
+		t.Errorf("flex spent: got %d, want 8000", dash.Flex.Spent)
+	}
+
+	// Subscription payment status.
+	if len(dash.Subscriptions) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(dash.Subscriptions))
+	}
+	s := dash.Subscriptions[0]
+	if s.Status != "paid" || s.Paid == nil || s.Paid.Amount != 186_000 {
+		t.Errorf("subscription status: %+v", s)
+	}
+	if s.Paid != nil && s.Paid.Date != "2026-06-05" {
+		t.Errorf("paid date: got %q, want 2026-06-05", s.Paid.Date)
+	}
+
+	// Calendar has one cell per June day.
+	if len(dash.Calendar) != 30 {
+		t.Errorf("calendar length: got %d, want 30", len(dash.Calendar))
+	}
+}
+
+func TestDashboard_RangeLabels(t *testing.T) {
+	cfg := budget.Config{Monthly: 5_000_000, ShopWeekly: 600_000, WeekendBudget: 200_000}
+	svc := NewService(fakeBudget{cfg}, fakeSubs{}, fakeExpenses{}, fixedClock(2026, 6, 23))
+	dash, err := svc.Dashboard(context.Background(), 2026, 6)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	// First June week is Mon Jun 1 .. Sun Jun 7 → "1–7 Jun".
+	if len(dash.BelanjaWeeks) == 0 || dash.BelanjaWeeks[0].Range != "1–7 Jun" {
+		t.Errorf("first week range: got %q, want %q", weekRangeOrEmpty(dash), "1–7 Jun")
+	}
+}
+
+func weekRangeOrEmpty(d Dashboard) string {
+	if len(d.BelanjaWeeks) == 0 {
+		return ""
+	}
+	return d.BelanjaWeeks[0].Range
+}

--- a/internal/platform/httpx/params.go
+++ b/internal/platform/httpx/params.go
@@ -1,0 +1,66 @@
+package httpx
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+)
+
+// DecodeJSON decodes the request body into v, returning an apierr.Invalid (400)
+// for malformed or empty JSON so handlers stay thin (spec §4.3).
+func DecodeJSON(r *http.Request, v any) error {
+	if r.Body == nil {
+		return apierr.Invalid("request body is required")
+	}
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		if errors.Is(err, io.EOF) {
+			return apierr.Invalid("request body is required")
+		}
+		return apierr.Invalid("invalid JSON body: %v", err)
+	}
+	return nil
+}
+
+// QueryYearMonth reads the year/month query params, falling back to the given
+// defaults (the current Asia/Jakarta month) when a param is absent. A malformed
+// value or an out-of-range month returns an apierr.Invalid (400).
+func QueryYearMonth(r *http.Request, defYear, defMonth int) (year, month int, err error) {
+	year, month = defYear, defMonth
+	q := r.URL.Query()
+	if v := q.Get("year"); v != "" {
+		year, err = strconv.Atoi(v)
+		if err != nil {
+			return 0, 0, apierr.Invalid("invalid year %q", v)
+		}
+	}
+	if v := q.Get("month"); v != "" {
+		month, err = strconv.Atoi(v)
+		if err != nil {
+			return 0, 0, apierr.Invalid("invalid month %q", v)
+		}
+	}
+	if month < 1 || month > 12 {
+		return 0, 0, apierr.Invalid("month must be between 1 and 12, got %d", month)
+	}
+	return year, month, nil
+}
+
+// PathUUID reads a {name} path param and parses it as a UUID, returning an
+// apierr.Invalid (400) when it is absent or malformed.
+func PathUUID(r *http.Request, name string) (uuid.UUID, error) {
+	raw := Param(r, name)
+	if raw == "" {
+		return uuid.UUID{}, apierr.Invalid("missing %s", name)
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.UUID{}, apierr.Invalid("invalid %s %q", name, raw)
+	}
+	return id, nil
+}

--- a/internal/platform/timeutil/timeutil.go
+++ b/internal/platform/timeutil/timeutil.go
@@ -16,6 +16,46 @@ import (
 // Loc is the single timezone used for every date/time decision.
 var Loc = mustLoadJakarta()
 
+// Clock returns the current instant. Services depend on a Clock (defaulting to
+// Now) so tests can pin "now" deterministically without touching the
+// environment. Effective-dated writes derive their month from it.
+type Clock func() time.Time
+
+// monthNames holds the full Indonesian month names, indexed 1..12.
+var monthNames = [...]string{
+	"", "Januari", "Februari", "Maret", "April", "Mei", "Juni",
+	"Juli", "Agustus", "September", "Oktober", "November", "Desember",
+}
+
+// monthAbbrs holds the short Indonesian month names, indexed 1..12.
+var monthAbbrs = [...]string{
+	"", "Jan", "Feb", "Mar", "Apr", "Mei", "Jun",
+	"Jul", "Agu", "Sep", "Okt", "Nov", "Des",
+}
+
+// MonthName returns the full Indonesian month name (e.g. 6 → "Juni"); month
+// must be 1..12, otherwise "" is returned.
+func MonthName(month int) string {
+	if month < 1 || month > 12 {
+		return ""
+	}
+	return monthNames[month]
+}
+
+// MonthAbbr returns the short Indonesian month name (e.g. 6 → "Jun"); month
+// must be 1..12, otherwise "" is returned.
+func MonthAbbr(month int) string {
+	if month < 1 || month > 12 {
+		return ""
+	}
+	return monthAbbrs[month]
+}
+
+// ParseDate parses a "YYYY-MM-DD" string as a midnight Asia/Jakarta date.
+func ParseDate(s string) (time.Time, error) {
+	return time.ParseInLocation("2006-01-02", s, Loc)
+}
+
 func mustLoadJakarta() *time.Location {
 	loc, err := time.LoadLocation("Asia/Jakarta")
 	if err != nil {

--- a/internal/subscription/handler.go
+++ b/internal/subscription/handler.go
@@ -1,0 +1,105 @@
+package subscription
+
+import (
+	"net/http"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/httpx"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// Handler serves the subscription definition endpoints (spec §7.3).
+type Handler struct {
+	svc *Service
+	now timeutil.Clock
+}
+
+// NewHandler builds a subscription Handler. now defaults to timeutil.Now when nil.
+func NewHandler(svc *Service, now timeutil.Clock) *Handler {
+	if now == nil {
+		now = timeutil.Now
+	}
+	return &Handler{svc: svc, now: now}
+}
+
+// Response is the JSON shape of a resolved subscription.
+type Response struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Color  string `json:"color"`
+	Alloc  int64  `json:"alloc"`
+	DueDay int16  `json:"due_day"`
+}
+
+func toResponse(r Resolved) Response {
+	return Response{
+		ID:     r.ID.String(),
+		Name:   r.Name,
+		Color:  r.Color,
+		Alloc:  r.Alloc,
+		DueDay: r.DueDay,
+	}
+}
+
+// List handles GET /subscriptions?year=&month= (defaults to the current month).
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) error {
+	year, month := timeutil.CurrentMonth(h.now())
+	year, month, err := httpx.QueryYearMonth(r, year, month)
+	if err != nil {
+		return err
+	}
+	subs, err := h.svc.Resolve(r.Context(), year, month)
+	if err != nil {
+		return err
+	}
+	out := make([]Response, 0, len(subs))
+	for _, s := range subs {
+		out = append(out, toResponse(s))
+	}
+	httpx.WriteJSON(w, http.StatusOK, out)
+	return nil
+}
+
+// Create handles POST /subscriptions.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) error {
+	var req CreateRequest
+	if err := httpx.DecodeJSON(r, &req); err != nil {
+		return err
+	}
+	sub, err := h.svc.Create(r.Context(), req)
+	if err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusCreated, toResponse(sub))
+	return nil
+}
+
+// Update handles PUT /subscriptions/{id}.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) error {
+	id, err := httpx.PathUUID(r, "id")
+	if err != nil {
+		return err
+	}
+	var req UpdateRequest
+	if err := httpx.DecodeJSON(r, &req); err != nil {
+		return err
+	}
+	sub, err := h.svc.Update(r.Context(), id, req)
+	if err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusOK, toResponse(sub))
+	return nil
+}
+
+// Delete handles DELETE /subscriptions/{id} → 204.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) error {
+	id, err := httpx.PathUUID(r, "id")
+	if err != nil {
+		return err
+	}
+	if err := h.svc.Delete(r.Context(), id); err != nil {
+		return err
+	}
+	httpx.WriteJSON(w, http.StatusNoContent, nil)
+	return nil
+}

--- a/internal/subscription/repo.go
+++ b/internal/subscription/repo.go
@@ -51,6 +51,40 @@ WHERE id = $1`
 	return s, nil
 }
 
+// Exists reports whether a subscription identity with id exists. Used by the
+// expense service to validate a Langganan expense's subscription_id (spec §7.5).
+func (r *Repo) Exists(ctx context.Context, id uuid.UUID) (bool, error) {
+	const q = `SELECT EXISTS (SELECT 1 FROM amplop.subscription WHERE id = $1)`
+	var exists bool
+	if err := r.db.GetContext(ctx, &exists, q, id); err != nil {
+		return false, fmt.Errorf("subscription exists %s: %w", id, err)
+	}
+	return exists, nil
+}
+
+// LatestVersion returns the most recent version with effective month ≤ (year,
+// month), regardless of active state. Used to merge partial edits and to carry
+// alloc/due_day forward when soft-ending a subscription (spec §5.2). Returns a
+// NotFound when no version exists at or before the month.
+func (r *Repo) LatestVersion(ctx context.Context, subscriptionID uuid.UUID, year, month int) (Version, error) {
+	const q = `
+SELECT id, subscription_id, effective_year, effective_month, alloc, due_day, active,
+       created_at, updated_at
+FROM amplop.subscription_version
+WHERE subscription_id = $1
+  AND (effective_year, effective_month) <= ($2, $3)
+ORDER BY effective_year DESC, effective_month DESC
+LIMIT 1`
+	var v Version
+	if err := r.db.GetContext(ctx, &v, q, subscriptionID, year, month); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Version{}, apierr.NotFound("subscription %s has no version for %d-%02d", subscriptionID, year, month)
+		}
+		return Version{}, fmt.Errorf("latest version %s %d-%02d: %w", subscriptionID, year, month, err)
+	}
+	return v, nil
+}
+
 // Resolve returns the active subscription set for (year, month) using the §5.1
 // lateral join query. Returns an empty slice when no active subscriptions exist.
 func (r *Repo) Resolve(ctx context.Context, year, month int) ([]Resolved, error) {

--- a/internal/subscription/service.go
+++ b/internal/subscription/service.go
@@ -1,0 +1,144 @@
+package subscription
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// repository is the subset of the subscription repo the service depends on. The
+// concrete *Repo satisfies it; tests use an in-memory fake.
+type repository interface {
+	ByID(ctx context.Context, id uuid.UUID) (Identity, error)
+	Resolve(ctx context.Context, year, month int) ([]Resolved, error)
+	LatestVersion(ctx context.Context, id uuid.UUID, year, month int) (Version, error)
+	CreateWithVersion(ctx context.Context, name, color string, year, month int, alloc int64, dueDay int16) (Identity, error)
+	UpdateIdentity(ctx context.Context, id uuid.UUID, name, color string) (Identity, error)
+	UpsertVersion(ctx context.Context, id uuid.UUID, year, month int, alloc int64, dueDay int16, active bool) error
+}
+
+// Service orchestrates subscription definition CRUD with effective-dated writes.
+type Service struct {
+	repo repository
+	now  timeutil.Clock
+}
+
+// NewService builds a subscription Service. now defaults to timeutil.Now when nil.
+func NewService(repo repository, now timeutil.Clock) *Service {
+	if now == nil {
+		now = timeutil.Now
+	}
+	return &Service{repo: repo, now: now}
+}
+
+// CreateRequest is the POST /subscriptions body (spec §7.3).
+type CreateRequest struct {
+	Name   string `json:"name"`
+	Color  string `json:"color"`
+	Alloc  int64  `json:"alloc"`
+	DueDay int    `json:"due_day"`
+}
+
+// UpdateRequest is the PUT /subscriptions/{id} body (spec §7.3). All fields are
+// optional; name/color update the identity, alloc/due_day upsert a version.
+type UpdateRequest struct {
+	Name   *string `json:"name"`
+	Color  *string `json:"color"`
+	Alloc  *int64  `json:"alloc"`
+	DueDay *int    `json:"due_day"`
+}
+
+// Resolve returns the active subscription set for (year, month).
+func (s *Service) Resolve(ctx context.Context, year, month int) ([]Resolved, error) {
+	return s.repo.Resolve(ctx, year, month)
+}
+
+// Create validates req and inserts an identity plus a version effective from the
+// current Asia/Jakarta month.
+func (s *Service) Create(ctx context.Context, req CreateRequest) (Resolved, error) {
+	if req.Name == "" {
+		return Resolved{}, apierr.Invalid("name is required")
+	}
+	if req.Alloc <= 0 {
+		return Resolved{}, apierr.Invalid("alloc must be > 0")
+	}
+	if req.DueDay < 1 || req.DueDay > 31 {
+		return Resolved{}, apierr.Invalid("due_day must be between 1 and 31")
+	}
+	year, month := timeutil.CurrentMonth(s.now())
+	ident, err := s.repo.CreateWithVersion(ctx, req.Name, req.Color, year, month, req.Alloc, int16(req.DueDay))
+	if err != nil {
+		return Resolved{}, err
+	}
+	return Resolved{ID: ident.ID, Name: ident.Name, Color: ident.Color, Alloc: req.Alloc, DueDay: int16(req.DueDay)}, nil
+}
+
+// Update applies a partial change: name/color update the identity (all months),
+// alloc/due_day upsert a version effective from the current month (spec §5.2).
+// It returns the subscription as it stands for the current month.
+func (s *Service) Update(ctx context.Context, id uuid.UUID, req UpdateRequest) (Resolved, error) {
+	ident, err := s.repo.ByID(ctx, id)
+	if err != nil {
+		return Resolved{}, err
+	}
+	year, month := timeutil.CurrentMonth(s.now())
+	latest, err := s.repo.LatestVersion(ctx, id, year, month)
+	if err != nil {
+		return Resolved{}, err
+	}
+
+	name, color := ident.Name, ident.Color
+	if req.Name != nil {
+		if *req.Name == "" {
+			return Resolved{}, apierr.Invalid("name is required")
+		}
+		name = *req.Name
+	}
+	if req.Color != nil {
+		color = *req.Color
+	}
+	if req.Name != nil || req.Color != nil {
+		if _, err := s.repo.UpdateIdentity(ctx, id, name, color); err != nil {
+			return Resolved{}, err
+		}
+	}
+
+	alloc, dueDay := latest.Alloc, int(latest.DueDay)
+	if req.Alloc != nil {
+		if *req.Alloc <= 0 {
+			return Resolved{}, apierr.Invalid("alloc must be > 0")
+		}
+		alloc = *req.Alloc
+	}
+	if req.DueDay != nil {
+		if *req.DueDay < 1 || *req.DueDay > 31 {
+			return Resolved{}, apierr.Invalid("due_day must be between 1 and 31")
+		}
+		dueDay = *req.DueDay
+	}
+	if req.Alloc != nil || req.DueDay != nil {
+		if err := s.repo.UpsertVersion(ctx, id, year, month, alloc, int16(dueDay), latest.Active); err != nil {
+			return Resolved{}, err
+		}
+	}
+
+	return Resolved{ID: id, Name: name, Color: color, Alloc: alloc, DueDay: int16(dueDay)}, nil
+}
+
+// Delete soft-ends a subscription: it upserts a version with active=false
+// effective from the current month, carrying alloc/due_day forward so past
+// months keep showing it (spec §5.2).
+func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
+	if _, err := s.repo.ByID(ctx, id); err != nil {
+		return err
+	}
+	year, month := timeutil.CurrentMonth(s.now())
+	latest, err := s.repo.LatestVersion(ctx, id, year, month)
+	if err != nil {
+		return err
+	}
+	return s.repo.UpsertVersion(ctx, id, year, month, latest.Alloc, latest.DueDay, false)
+}

--- a/internal/subscription/service_test.go
+++ b/internal/subscription/service_test.go
@@ -1,0 +1,242 @@
+package subscription
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ishanwardhono/expense-function/internal/platform/apierr"
+	"github.com/ishanwardhono/expense-function/internal/platform/httpx"
+	"github.com/ishanwardhono/expense-function/internal/platform/timeutil"
+)
+
+// fakeRepo is an in-memory subscription repository.
+type fakeRepo struct {
+	idents   map[uuid.UUID]Identity
+	versions map[uuid.UUID][]Version // per subscription, append-only
+}
+
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{idents: map[uuid.UUID]Identity{}, versions: map[uuid.UUID][]Version{}}
+}
+
+func (f *fakeRepo) ByID(_ context.Context, id uuid.UUID) (Identity, error) {
+	ident, ok := f.idents[id]
+	if !ok {
+		return Identity{}, apierr.NotFound("subscription %s not found", id)
+	}
+	return ident, nil
+}
+
+func (f *fakeRepo) Resolve(_ context.Context, year, month int) ([]Resolved, error) {
+	var out []Resolved
+	for id, ident := range f.idents {
+		v, err := f.LatestVersion(context.Background(), id, year, month)
+		if err != nil || !v.Active {
+			continue
+		}
+		out = append(out, Resolved{ID: id, Name: ident.Name, Color: ident.Color, Alloc: v.Alloc, DueDay: v.DueDay})
+	}
+	return out, nil
+}
+
+func (f *fakeRepo) LatestVersion(_ context.Context, id uuid.UUID, year, month int) (Version, error) {
+	best := Version{}
+	found := false
+	for _, v := range f.versions[id] {
+		y, m := int(v.EffectiveYear), int(v.EffectiveMonth)
+		if y < year || (y == year && m <= month) {
+			if !found || y > int(best.EffectiveYear) || (y == int(best.EffectiveYear) && m > int(best.EffectiveMonth)) {
+				best = v
+				found = true
+			}
+		}
+	}
+	if !found {
+		return Version{}, apierr.NotFound("subscription %s has no version for %d-%02d", id, year, month)
+	}
+	return best, nil
+}
+
+func (f *fakeRepo) CreateWithVersion(_ context.Context, name, color string, year, month int, alloc int64, dueDay int16) (Identity, error) {
+	id := uuid.New()
+	ident := Identity{ID: id, Name: name, Color: color}
+	f.idents[id] = ident
+	f.versions[id] = append(f.versions[id], Version{
+		SubscriptionID: id, EffectiveYear: int16(year), EffectiveMonth: int16(month),
+		Alloc: alloc, DueDay: dueDay, Active: true,
+	})
+	return ident, nil
+}
+
+func (f *fakeRepo) UpdateIdentity(_ context.Context, id uuid.UUID, name, color string) (Identity, error) {
+	ident, ok := f.idents[id]
+	if !ok {
+		return Identity{}, apierr.NotFound("subscription %s not found", id)
+	}
+	ident.Name, ident.Color = name, color
+	f.idents[id] = ident
+	return ident, nil
+}
+
+func (f *fakeRepo) UpsertVersion(_ context.Context, id uuid.UUID, year, month int, alloc int64, dueDay int16, active bool) error {
+	for i, v := range f.versions[id] {
+		if int(v.EffectiveYear) == year && int(v.EffectiveMonth) == month {
+			f.versions[id][i].Alloc = alloc
+			f.versions[id][i].DueDay = dueDay
+			f.versions[id][i].Active = active
+			return nil
+		}
+	}
+	f.versions[id] = append(f.versions[id], Version{
+		SubscriptionID: id, EffectiveYear: int16(year), EffectiveMonth: int16(month),
+		Alloc: alloc, DueDay: dueDay, Active: active,
+	})
+	return nil
+}
+
+func fixedClock(y, m, d int) timeutil.Clock {
+	return func() time.Time { return timeutil.Date(y, m, d) }
+}
+
+func TestCreate_Validation(t *testing.T) {
+	svc := NewService(newFakeRepo(), fixedClock(2026, 6, 23))
+	cases := []CreateRequest{
+		{Name: "", Alloc: 1000, DueDay: 5},
+		{Name: "Netflix", Alloc: 0, DueDay: 5},
+		{Name: "Netflix", Alloc: 1000, DueDay: 0},
+		{Name: "Netflix", Alloc: 1000, DueDay: 32},
+	}
+	for i, req := range cases {
+		_, err := svc.Create(context.Background(), req)
+		var ae *apierr.Error
+		if !errors.As(err, &ae) || ae.Kind != apierr.KindInvalid {
+			t.Errorf("case %d: expected Invalid, got %v", i, err)
+		}
+	}
+}
+
+func TestCreate_Then_Resolve(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo, fixedClock(2026, 6, 23))
+	sub, err := svc.Create(context.Background(), CreateRequest{Name: "Netflix", Color: "#c8403c", Alloc: 187_000, DueDay: 5})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if sub.ID == (uuid.UUID{}) || sub.Alloc != 187_000 {
+		t.Fatalf("unexpected created sub: %+v", sub)
+	}
+	got, err := svc.Resolve(context.Background(), 2026, 6)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("Resolve: got %d subs (%v)", len(got), err)
+	}
+	// Created in June: absent from May (its earliest version > May).
+	may, _ := svc.Resolve(context.Background(), 2026, 5)
+	if len(may) != 0 {
+		t.Errorf("subscription should be absent from May, got %d", len(may))
+	}
+}
+
+func TestUpdate_PartialPreservesOtherField(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo, fixedClock(2026, 6, 23))
+	sub, _ := svc.Create(context.Background(), CreateRequest{Name: "Netflix", Alloc: 187_000, DueDay: 5})
+
+	newAlloc := int64(200_000)
+	updated, err := svc.Update(context.Background(), sub.ID, UpdateRequest{Alloc: &newAlloc})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Alloc != 200_000 {
+		t.Errorf("alloc: got %d, want 200000", updated.Alloc)
+	}
+	if updated.DueDay != 5 {
+		t.Errorf("due_day should be preserved at 5, got %d", updated.DueDay)
+	}
+
+	newName := "Netflix Premium"
+	renamed, err := svc.Update(context.Background(), sub.ID, UpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update name: %v", err)
+	}
+	if renamed.Name != "Netflix Premium" || renamed.Alloc != 200_000 {
+		t.Errorf("rename should preserve alloc 200000: %+v", renamed)
+	}
+}
+
+func TestUpdate_NotFound(t *testing.T) {
+	svc := NewService(newFakeRepo(), fixedClock(2026, 6, 23))
+	name := "x"
+	_, err := svc.Update(context.Background(), uuid.New(), UpdateRequest{Name: &name})
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestDelete_SoftEndKeepsPastMonths(t *testing.T) {
+	repo := newFakeRepo()
+	// Create in May 2026.
+	svcMay := NewService(repo, fixedClock(2026, 5, 10))
+	sub, _ := svcMay.Create(context.Background(), CreateRequest{Name: "Netflix", Alloc: 187_000, DueDay: 5})
+
+	// Delete in June 2026.
+	svcJun := NewService(repo, fixedClock(2026, 6, 10))
+	if err := svcJun.Delete(context.Background(), sub.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// May still shows it (frozen); June onward does not.
+	may, _ := svcJun.Resolve(context.Background(), 2026, 5)
+	if len(may) != 1 {
+		t.Errorf("May should still show the subscription, got %d", len(may))
+	}
+	jun, _ := svcJun.Resolve(context.Background(), 2026, 6)
+	if len(jun) != 0 {
+		t.Errorf("June should not show the soft-ended subscription, got %d", len(jun))
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	svc := NewService(newFakeRepo(), fixedClock(2026, 6, 23))
+	err := svc.Delete(context.Background(), uuid.New())
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindNotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestHandler_Update_BadUUID(t *testing.T) {
+	h := NewHandler(NewService(newFakeRepo(), fixedClock(2026, 6, 23)), fixedClock(2026, 6, 23))
+	// Route through the real router so the {id} path param is populated.
+	rt := httpx.NewRouter()
+	rt.Handle(http.MethodPut, "/subscriptions/{id}", h.Update)
+	req := httptest.NewRequest(http.MethodPut, "/subscriptions/not-a-uuid", strings.NewReader(`{}`))
+	err := rt.ServeHTTP(httptest.NewRecorder(), req)
+	var ae *apierr.Error
+	if !errors.As(err, &ae) || ae.Kind != apierr.KindInvalid {
+		t.Fatalf("expected Invalid, got %v", err)
+	}
+}
+
+func TestHandler_List_OK(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo, fixedClock(2026, 6, 23))
+	_, _ = svc.Create(context.Background(), CreateRequest{Name: "Netflix", Alloc: 187_000, DueDay: 5})
+	h := NewHandler(svc, fixedClock(2026, 6, 23))
+
+	req := httptest.NewRequest(http.MethodGet, "/subscriptions", nil)
+	rec := httptest.NewRecorder()
+	if err := h.List(rec, req); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Netflix") {
+		t.Errorf("unexpected response %d %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Intent

Implements **Phase 3 — Services + HTTP** from the v2 spec (`docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md` §8). Builds the service + handler layers on top of the Phase 2 repos and wires every §7 endpoint into the single routed `Expense` Cloud Function.

## Scope

- **budget** — `Service` (resolve + effective-from-current-month upsert with `>= 0` validation); `GET /budget`, `PUT /budget`.
- **subscription** — `Service` (resolve, create, partial update that merges the latest version, soft-end delete carrying alloc/due_day forward); new `Exists` + `LatestVersion` repo helpers; `GET/POST/PUT/DELETE /subscriptions` (effective-dated per §5.2).
- **expense** — `Service` enforcing the Langganan ⇔ `subscription_id` rule (§7.5) and the once-per-month payment pre-check → **409** (DB unique partial index remains the backstop); `POST/PUT/DELETE /expenses`; shared expense `Response` DTO (with derived envelope badge) reused by the month day-list.
- **month** — `Service` resolves config + subs + the wide boundary-window expenses (§6.2), runs the **pure** engine, and assembles the §7.1 dashboard (period/stats/envelopes/weeks/weekends/flex/calendar/days/subscriptions); `GET /month`.
- **platform** — `timeutil.Clock`, Indonesian `MonthName`/`MonthAbbr`, `ParseDate`; `EnvelopeID.ShortLabel`; `httpx` JSON-decode / query-year-month / path-UUID helpers (all map to typed errors per §4.3).
- **function.go** — lazy **connect-on-first-request** DB provider (serverless cold-start; `init()` never fails on bad env) wiring all §7 routes through the CORS/error middleware.

## Design decisions (confirmed with maintainer)

- Services depend on small **repo interfaces** and an **injected clock**, so service/handler tests use in-memory fakes — all run under plain `go test ./...` with **no DB**.
- DB connection is **lazy** (`sync.Once`); a connect error surfaces as a 500 on the request, not a startup crash.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test ./...` — **all green**.
- `go build -tags integration ./...` / `go vet -tags integration ./internal/...` — compile-green (Phase 2 integration tests untouched, skip without `DB_HOST`).
- New fake-based tests cover happy paths plus **400** (validation/bad JSON/bad query/bad UUID), **404** (unknown id), and **409** (duplicate Langganan payment, incl. update-excludes-self and a different-month succeeds); effective-dating freeze/soft-end; month assembly incl. the cross-boundary attribution case (Jun-29 belanja counts toward July's week but stays visible in June's day list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)