### PR TITLE
fix: resolve CI IAM gaps for deploy and terraform workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,9 +49,14 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Deploy to Cloud Run
+        env:
+          # Run the source build as the deployer SA itself (not the default compute
+          # SA), so the build has the exact roles Terraform grants it.
+          DEPLOY_SA_EMAIL: ${{ vars.DEPLOY_SA_EMAIL }}
         run: |
           gcloud run deploy "$SERVICE_NAME" \
             --source=. \
             --region="$REGION" \
             --function=Expense \
+            --build-service-account="$DEPLOY_SA_EMAIL" \
             --project="$PROJECT_ID"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Terraform plan
         id: plan
         run: |
+          # pipefail so a failed `terraform plan` fails the step — without it the
+          # pipe's exit status is tee's (0) and a real plan error passes silently.
+          set -o pipefail
           terraform plan -no-color -input=false | tee plan.txt
           {
             echo '### Terraform plan';

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ REGION       ?= asia-southeast1
 SERVICE_NAME ?= expense
 TFSTATE_BUCKET ?= weekly-expense-tfstate
 GH_REPO      ?= ishanwardhono/expense-functions
+DEPLOY_SA    ?= $(SERVICE_NAME)-deployer@$(PROJECT_ID).iam.gserviceaccount.com
+INFRA_SA     ?= $(SERVICE_NAME)-infra@$(PROJECT_ID).iam.gserviceaccount.com
 
 # One-time: create the GCS bucket that holds Terraform state (must exist before
 # `terraform init` can use the gcs backend).
@@ -36,6 +38,15 @@ tf-bootstrap:
 	gcloud storage buckets create gs://$(TFSTATE_BUCKET) \
 		--project=$(PROJECT_ID) --location=$(REGION) --uniform-bucket-level-access
 	gcloud storage buckets update gs://$(TFSTATE_BUCKET) --versioning
+
+# One-time (after the first `tf-apply` creates the infra SA): grant that SA
+# read/write on the Terraform state objects. Done out-of-band — not in the module —
+# because the infra SA can't manage its own state-bucket IAM from inside its own
+# apply (it lacks bucket-level getIamPolicy). Run by an owner with bucket admin.
+tf-grant-state:
+	gcloud storage buckets add-iam-policy-binding gs://$(TFSTATE_BUCKET) \
+		--member="serviceAccount:$(INFRA_SA)" \
+		--role="roles/storage.objectAdmin"
 
 tf-init:
 	cd terraform && terraform init
@@ -64,6 +75,7 @@ gh-vars:
 deploy:
 	gcloud run deploy $(SERVICE_NAME) \
 		--source=. --region=$(REGION) \
-		--function=Expense --project=$(PROJECT_ID)
+		--function=Expense --build-service-account=$(DEPLOY_SA) \
+		--project=$(PROJECT_ID)
 
-.PHONY: run run-expense migrate-up tf-bootstrap tf-init tf-plan tf-apply gh-vars deploy
+.PHONY: run run-expense migrate-up tf-bootstrap tf-grant-state tf-init tf-plan tf-apply gh-vars deploy

--- a/README.md
+++ b/README.md
@@ -206,8 +206,14 @@ versions add …` for the password, and the CA cert).
 make tf-bootstrap   # create the GCS bucket that stores Terraform state
 make tf-init        # download the Google provider
 make tf-apply       # review the plan, type "yes" — creates the service + 3 SAs + WIF
+make tf-grant-state # let the infra SA read/write state (so CI applies can run)
 make gh-vars        # push WIF_PROVIDER, DEPLOY_SA_EMAIL, TF_INFRA_SA_EMAIL into GitHub
 ```
+
+`make tf-grant-state` grants the `expense-infra` SA `roles/storage.objectAdmin` on
+the state bucket. It is done here (out-of-band, by you) rather than in the module:
+the infra SA can't manage its own state-bucket IAM from inside its own apply, so
+Terraform owning that binding would 403 every CI apply.
 
 `make gh-vars` sets the repo **Actions variables** the workflows read (via `gh`, no
 copy-paste). Until they exist, both workflows **skip** (they guard on
@@ -237,6 +243,24 @@ Environments → **New environment** → `production` → add yourself as a requ
 Without it, deploys/applies just run automatically (no pause).
 
 **Done.** From here on, use Need #2 and Need #3 below.
+
+### Decommissioning the v1 functions (one-time)
+
+The v2 backend is a **single** `expense` Cloud Run service (`--function=Expense`).
+If the project still holds the old v1 functions (`WeeklyGet`, `MonthlyGet`,
+`RecapGet`, `hello`, …) from before the rewrite, delete them so only `expense`
+remains. These are not Terraform-managed — remove them out-of-band with `gcloud`:
+
+```bash
+# Discover what's still deployed
+gcloud functions list --project=weekly-expense
+gcloud run services list --project=weekly-expense --region=asia-southeast1
+
+# Delete each stale v1 function (keep `expense`):
+gcloud functions delete <NAME> --region=asia-southeast1 --project=weekly-expense
+# …or, if it shows up as a Cloud Run service instead:
+gcloud run services delete <NAME> --region=asia-southeast1 --project=weekly-expense
+```
 
 ### Need #2 — change infrastructure
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -304,14 +304,17 @@ resource "google_service_account" "deploy" {
   display_name = "Expense v2 CI deployer SA"
 }
 
-# Roles needed to build (Cloud Build buildpacks), push the image (Artifact Registry),
-# stage the source (GCS), and roll out a new Cloud Run revision.
+# Roles needed to submit the build (Cloud Build), and — since the deploy SA is also
+# the build service account (see deploy.yml's --build-service-account) — to write
+# build logs (logging.logWriter), push the image (Artifact Registry), and stage the
+# source (GCS), plus roll out a new Cloud Run revision.
 resource "google_project_iam_member" "deploy_roles" {
   for_each = toset([
     "roles/run.developer",
     "roles/cloudbuild.builds.editor",
     "roles/artifactregistry.writer",
     "roles/storage.admin",
+    "roles/logging.logWriter",
   ])
 
   project = local.project_id
@@ -322,6 +325,16 @@ resource "google_project_iam_member" "deploy_roles" {
 # The deploy SA must be able to deploy the service *as* the runtime SA.
 resource "google_service_account_iam_member" "deploy_act_as_runtime" {
   service_account_id = google_service_account.runtime.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.deploy.email}"
+}
+
+# `gcloud run deploy --source` runs a Cloud Build as the build service account.
+# We pass the deploy SA itself (deploy.yml --build-service-account), so it must be
+# able to act as itself — Cloud Build requires the submitter to have act-as on the
+# build SA. This avoids depending on the project's default compute SA.
+resource "google_service_account_iam_member" "deploy_act_as_self" {
+  service_account_id = google_service_account.deploy.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.deploy.email}"
 }
@@ -364,12 +377,11 @@ resource "google_project_iam_member" "infra_roles" {
   member  = "serviceAccount:${google_service_account.infra.email}"
 }
 
-# Read/write the Terraform state objects in the state bucket.
-resource "google_storage_bucket_iam_member" "infra_state" {
-  bucket = local.tfstate_bucket
-  role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${google_service_account.infra.email}"
-}
+# NOTE: the infra SA's access to the state bucket is granted out-of-band (one-time
+# setup: `make tf-grant-state`), NOT here. Managing that bucket-IAM binding from
+# inside this module would be a bootstrap chicken-and-egg — reconciling it requires
+# storage.buckets.getIamPolicy, which the infra SA (object-level state access only)
+# lacks, so the apply would 403 on its own state bucket.
 
 # Apply the Cloud Run service *as* the runtime SA.
 resource "google_service_account_iam_member" "infra_act_as_runtime" {


### PR DESCRIPTION
## Intent

The merge of PR #15 (v2 Terraform IaC + CI/CD) left two **red checks on `main`**. Investigation shows the suspicion that CI deploys to *old* cloud functions is a misconception — the pipeline already targets a single `--function=Expense`. Both failures are **IAM permission gaps** in the freshly-provisioned setup, independent of each other.

## Scope

**1. `deploy` failed** — `PERMISSION_DENIED: caller does not have permission to act as service account …/compute@…`. `gcloud run deploy --source` builds via Cloud Build as the project's **default compute SA**, which `expense-deployer` can't act as.
- Pass `--build-service-account` so the build runs **as the deployer SA itself** (least-privilege, no reliance on the deprecated default compute SA).
- Terraform: grant the deploy SA `roles/logging.logWriter` (build logs) + `iam.serviceAccountUser` on itself.

**2. `terraform` failed** — `expense-infra … does not have storage.buckets.getIamPolicy access to … tfstate` at `google_storage_bucket_iam_member.infra_state`. Bootstrap chicken-and-egg: the infra SA can't manage its own state-bucket IAM from inside its own apply.
- Remove `infra_state` from the module; grant that access out-of-band via a new `make tf-grant-state` target (documented in README first-time setup).

**3. v1 cleanup** — documented one-time `gcloud` commands to delete leftover v1 functions so only `expense` remains.

## Required one-time migration (owner, local — before merge takes effect cleanly)

The `infra_state` binding currently exists in remote state. Drop it **without revoking** the binding so the next CI apply doesn't try to destroy it (and 403 again):

```bash
cd terraform && terraform state rm google_storage_bucket_iam_member.infra_state
```

## Test plan

- `terraform fmt -check` + `terraform validate` → pass (run locally).
- This PR's **terraform** check posts a plan: expect `+ deploy_act_as_self`, `+ deploy_roles[logging.logWriter]`, and **no destroy** of `infra_state` once the state-rm above is done.
- On merge to `main`: both **deploy** and **terraform** jobs should go green (each pauses on the `production` approval gate).
- No Go/application code changes — CI/IaC only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)