### PR TITLE
fix: correct --build-service-account path so deploy succeeds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,5 +58,5 @@ jobs:
             --source=. \
             --region="$REGION" \
             --function=Expense \
-            --build-service-account="$DEPLOY_SA_EMAIL" \
+            --build-service-account="projects/$PROJECT_ID/serviceAccounts/$DEPLOY_SA_EMAIL" \
             --project="$PROJECT_ID"

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ gh-vars:
 deploy:
 	gcloud run deploy $(SERVICE_NAME) \
 		--source=. --region=$(REGION) \
-		--function=Expense --build-service-account=$(DEPLOY_SA) \
+		--function=Expense \
+		--build-service-account=projects/$(PROJECT_ID)/serviceAccounts/$(DEPLOY_SA) \
 		--project=$(PROJECT_ID)
 
 .PHONY: run run-expense migrate-up tf-bootstrap tf-grant-state tf-init tf-plan tf-apply gh-vars deploy


### PR DESCRIPTION
## Intent

Follow-up to #16. After that merge, the **deploy** workflow still failed:

```
ERROR: (gcloud) Invalid service account value [expense-deployer@weekly-expense.iam.gserviceaccount.com].
The service account value must follow the pattern projects/<projectId>/serviceAccounts/<serviceAccount>.
```

`gcloud run deploy --build-service-account` needs the **full resource path**, not the bare email.

## Change

- `deploy.yml` + `Makefile`: pass `projects/$PROJECT_ID/serviceAccounts/$DEPLOY_SA_EMAIL`.

## Related out-of-band fixes already applied (context)

These were done directly against GCP/state (not in this diff) to unblock CI:

- **Deleted** the 5 stale v1 Cloud Build triggers (`rmgpgab-*`) that auto-deployed old functions on every push — these were the 5 failing "Cloud Build" checks.
- **Imported** the pre-existing `cloud-run-source-deploy` Artifact Registry repo into Terraform state (it already existed, so `terraform apply` was trying to *create* it → 403). The infra SA already has `artifactregistry.admin`, so the next sanctioned `terraform` apply converges cleanly (`0 to add, 2 to change`).

## Test plan

- Merge → **deploy** workflow builds as the deployer SA (now a valid path) and rolls out a new `expense` revision.
- Separately re-run the **terraform** workflow on `main`; with the AR repo imported it applies the 2 in-place changes and goes green.
- Confirm only `expense` remains: `gcloud run services list --region=asia-southeast1` (after the 5 old services are deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)