### PR TITLE
chore: remove dead local + stop terraform plan churn after deploys

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,10 +36,6 @@ locals {
   region       = "asia-southeast1"
   service_name = "expense"
 
-  # GCS bucket holding Terraform state (created by `make tf-bootstrap`). Must match
-  # the bucket in the `backend "gcs"` block above and the Makefile's TFSTATE_BUCKET.
-  tfstate_bucket = "weekly-expense-tfstate"
-
   # owner/name of the GitHub repo allowed to deploy via Workload Identity Federation.
   github_repo = "ishanwardhono/expense-functions"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -238,14 +238,18 @@ resource "google_cloud_run_v2_service" "expense" {
     }
   }
 
-  # The deploy pipeline (gcloud run deploy --source) owns image rollouts. Ignore the
-  # image plus the client tags gcloud stamps on each deploy, so `terraform plan`
-  # stays clean after a code deploy.
+  # The deploy pipeline (gcloud run deploy --source) owns image rollouts. Ignore what
+  # gcloud stamps on each source deploy so `terraform plan` stays clean afterward:
+  #   - the rolled-out image and client tags, and
+  #   - the top-level build_config + service-level scaling blocks gcloud adds (these
+  #     are distinct from the template.scaling.max_instance_count we manage above).
   lifecycle {
     ignore_changes = [
       template[0].containers[0].image,
       client,
       client_version,
+      build_config,
+      scaling,
     ]
   }
 


### PR DESCRIPTION
## Intent

Cleanup of issues surfaced after today's CI fixes (#16/#17). Two small Terraform changes:

### 1. Remove orphaned `local.tfstate_bucket`
Only ever used by `google_storage_bucket_iam_member.infra_state`, which #16 removed (state-bucket access moved to `make tf-grant-state`). The `gcs` backend can't reference a local anyway, so it was dead/misleading. Bucket name stays documented in the `backend "gcs"` block.

### 2. Ignore gcloud-stamped `build_config` + `scaling` in the service lifecycle
Pre-existing gap from #15: every `gcloud run deploy --source` stamps a top-level `build_config` and service-level `scaling` block onto the `expense` service. Terraform didn't declare them, so **every** plan showed a spurious `1 to change` and each apply stripped them (re-added on the next deploy — pure churn). Added both to `ignore_changes`. These are distinct from the `template.scaling.max_instance_count` we still manage.

## Test plan

- `terraform fmt -check` ✅ and `terraform validate` ✅.
- `terraform plan` now reports **"No changes. Your infrastructure matches the configuration."** (was `1 to change` before).
- No infra mutation — config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)