### PR TITLE
fix: attribute Lainnya to Fleksibel on any day

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ migrations/            0001_init_amplop.sql
 
 Key cross-cutting domain rules (full detail in the spec — these require reading several prototype files to grasp, so they are summarized here):
 
-- **Four envelopes, derived (not stored)** from an expense's category + day-of-week: `belanja` (Belanja/Cash any day; Makan/Jajan on weekdays), `weekend` (Makan/Jajan/Lainnya on Sat–Sun), `fleksibel` (Lainnya on weekdays), `langganan` (category Langganan). See `EnvelopeOf` (spec §6.1).
+- **Four envelopes, derived (not stored)** from an expense's category + day-of-week: `belanja` (Belanja/Cash any day; Makan/Jajan on weekdays), `weekend` (Makan/Jajan on Sat–Sun), `fleksibel` (Lainnya any day), `langganan` (category Langganan). See `EnvelopeOf` (spec §6.1).
 - **Month boundaries:** a shopping week (Mon–Sun) belongs to the month of its **Friday**; a weekend (Sat+Sun) to the month of its **Saturday**. A transaction can show in month *M*'s calendar yet count toward a neighbor month's envelope (spec §6.2). No carry-over between days/weeks.
 - **Effective-date resolution** (spec §5.1/§5.2): the engine stays pure by receiving the *resolved* config + subscription set; versioning logic lives in the repo/service.
 

--- a/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
+++ b/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
@@ -276,7 +276,7 @@ Operates on the **already-resolved** month context (config + subscription set pa
 - `Langganan` → **langganan** (any day).
 - `Belanja` or `Cash` → **belanja** (any day).
 - `Makan` or `Jajan` → weekend day ⇒ **weekend**, else **belanja**.
-- `Lainnya` → weekend day ⇒ **weekend**, else **fleksibel**.
+- `Lainnya` → **fleksibel** (any day).
 
 "weekend day" = Saturday or Sunday. (This extends `amplopOf` with the Langganan case; subscription payments are now ordinary expenses, so no separate handling.)
 

--- a/internal/envelope/engine_test.go
+++ b/internal/envelope/engine_test.go
@@ -34,8 +34,8 @@ func TestEnvelopeOf(t *testing.T) {
 		{"Jajan weekday", CatJajan, weekday, EnvBelanja},
 		{"Jajan weekend", CatJajan, saturday, EnvWeekend},
 		{"Lainnya weekday", CatLainnya, weekday, EnvFleksibel},
-		{"Lainnya saturday", CatLainnya, saturday, EnvWeekend},
-		{"Lainnya sunday", CatLainnya, sunday, EnvWeekend},
+		{"Lainnya saturday", CatLainnya, saturday, EnvFleksibel},
+		{"Lainnya sunday", CatLainnya, sunday, EnvFleksibel},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/envelope/rules.go
+++ b/internal/envelope/rules.go
@@ -76,7 +76,7 @@ func isWeekend(date time.Time) bool {
 //   - Langganan        → langganan (any day)
 //   - Belanja / Cash   → belanja (any day)
 //   - Makan / Jajan    → weekend on Sat/Sun, else belanja
-//   - Lainnya          → weekend on Sat/Sun, else fleksibel
+//   - Lainnya          → fleksibel (any day)
 func EnvelopeOf(cat Category, date time.Time) EnvelopeID {
 	switch cat {
 	case CatLangganan:
@@ -89,9 +89,6 @@ func EnvelopeOf(cat Category, date time.Time) EnvelopeID {
 		}
 		return EnvBelanja
 	case CatLainnya:
-		if isWeekend(date) {
-			return EnvWeekend
-		}
 		return EnvFleksibel
 	}
 	// Unknown category: treat as flexible (defensive; validation rejects these).

--- a/internal/month/service_test.go
+++ b/internal/month/service_test.go
@@ -50,7 +50,7 @@ func TestDashboard_Assembly(t *testing.T) {
 	exps := []expense.Expense{
 		exp(timeutil.Date(2026, 6, 15), 18_000, "Makan", nil),        // weekday → belanja, June week
 		exp(timeutil.Date(2026, 6, 5), 186_000, "Langganan", &subID), // langganan, paid
-		exp(timeutil.Date(2026, 6, 16), 8_000, "Lainnya", nil),       // weekday → fleksibel
+		exp(timeutil.Date(2026, 6, 16), 8_000, "Lainnya", nil),       // Lainnya → fleksibel
 		exp(timeutil.Date(2026, 6, 29), 50_000, "Belanja", nil),      // week owned by July's Friday
 	}
 


### PR DESCRIPTION
## Intent

A `Lainnya` (miscellaneous) expense was attributed to a **different** envelope depending on the day: weekday → **Fleksibel**, but Saturday/Sunday → **Akhir Pekan** (weekend). Since `Lainnya` is the catch-all/flexible category, the same discretionary purchase (e.g. a toy) counting against the weekend budget on Saturday but the flexible budget on Friday is surprising. This maps `Lainnya` to **Fleksibel on any day**.

`Makan`/`Jajan` on Sat/Sun still go to the weekend envelope — only `Lainnya` changes. Weekend now means strictly weekend food/leisure.

## Scope

- `internal/envelope/rules.go` — `EnvelopeOf`: drop the weekend branch for `CatLainnya`; update the doc comment.
- `internal/envelope/engine_test.go` — the two weekend `Lainnya` table cases now expect `EnvFleksibel`.
- `docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md` §6.1 and `CLAUDE.md` envelope summary — keep the rule docs in sync.
- `internal/month/service_test.go` — clarify a now-misleading inline comment.

**No DB migration / no data backfill.** Envelopes are derived at read time, so all past months re-attribute automatically on the next `GET /month`. Observed real case: the `2026-07-05` (Sun) "mainan shana" expense in prod moves from Akhir Pekan → Fleksibel.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `go test ./...` — green. The `June2026Seed` engine fixture is unaffected (its `Lainnya` entries fall on weekdays), which confirms no unintended regression to weekend/flex totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)