### PR TITLE
feat: Phase 6 — Fleksibel rollover (D9/§6.6)

### DIFF
--- a/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
+++ b/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
@@ -455,9 +455,9 @@ Each phase ends green (compiles, tests pass). TDD for the engine and the effecti
 ### Phase 5 — AI scan import (deferred; see §9)
 
 ### Phase 6 — Fleksibel rollover (D9/§6.6 — added 2026-07-14)
-- [ ] Engine: `RolloverItem` type; compute `rollover` + `rollover_items` in `ComputeMonth` (past pills' `left`; paid subs' `alloc − paid`); fleksibel row `left = flexBudget + rollover − flexSpent`, `over = left < 0`.
-- [ ] `month` service/handler: expose `flex.rollover` + `flex.rollover_items` (§7.1).
-- [ ] Engine tests: mid-month mix of past/current/future pills; month start (rollover 0); past-month view (all closed); negative rollover pushing fleksibel `over`; overpaid/underpaid/unpaid subscriptions; boundary week owned by neighbor month; zero-amount items included.
+- [x] Engine: `RolloverItem` type; compute `rollover` + `rollover_items` in `ComputeMonth` (past pills' `left`; paid subs' `alloc − paid`); fleksibel row `left = flexBudget + rollover − flexSpent`, `over = left < 0`.
+- [x] `month` service/handler: expose `flex.rollover` + `flex.rollover_items` (§7.1).
+- [x] Engine tests: mid-month mix of past/current/future pills; month start (rollover 0); past-month view (all closed); negative rollover pushing fleksibel `over`; overpaid/underpaid/unpaid subscriptions; boundary week owned by neighbor month; zero-amount items included.
 - [ ] Frontend (separate repo, out of scope here): Fleksibel detail sheet renders the rollover breakdown; envelope card shows the adjusted `left`.
 
 ---

--- a/internal/envelope/engine.go
+++ b/internal/envelope/engine.go
@@ -61,6 +61,26 @@ type Weekend struct {
 	State    State
 }
 
+// RolloverType identifies the kind of closed source behind a RolloverItem.
+type RolloverType string
+
+const (
+	RolloverWeek         RolloverType = "week"
+	RolloverWeekend      RolloverType = "weekend"
+	RolloverSubscription RolloverType = "subscription"
+)
+
+// RolloverItem is one closed source's contribution to the fleksibel rollover
+// (spec §6.6). Week/weekend items carry Start/End; subscription items carry
+// Name. Zero amounts are kept — the breakdown is a complete audit trail.
+type RolloverItem struct {
+	Type   RolloverType
+	Start  time.Time
+	End    time.Time
+	Name   string
+	Amount int64
+}
+
 // Row is one envelope summary row.
 type Row struct {
 	ID     EnvelopeID
@@ -91,6 +111,12 @@ type MonthResult struct {
 	SubsAlloc      int64
 	LanggananSpent int64
 	FlexSpent      int64
+
+	// Rollover (§6.6): Σ leftover of closed sources — past week/weekend pills
+	// and paid subscriptions (alloc − paid) — both signs. It raises/lowers the
+	// fleksibel row's Left only; FlexBudget and Sisa are untouched.
+	Rollover      int64
+	RolloverItems []RolloverItem
 
 	ShopBudget int64
 	ShopSpent  int64
@@ -196,11 +222,39 @@ func ComputeMonth(in MonthInput) MonthResult {
 	flexBudget := cfg.Monthly - shopBudget - wkndBudget - subsAlloc
 	totalSpent := shopSpent + wkndSpent + langgananSpent + flexSpent
 
+	// Rollover (§6.6): closed sources flush their leftover into fleksibel.
+	// Current/future pills and unpaid subscriptions contribute nothing.
+	var rollover int64
+	var rolloverItems []RolloverItem
+	for _, w := range weeks {
+		if w.State != StatePast {
+			continue
+		}
+		rollover += w.Left
+		rolloverItems = append(rolloverItems, RolloverItem{Type: RolloverWeek, Start: w.Monday, End: w.Sunday, Amount: w.Left})
+	}
+	for _, w := range weekends {
+		if w.State != StatePast {
+			continue
+		}
+		rollover += w.Left
+		rolloverItems = append(rolloverItems, RolloverItem{Type: RolloverWeekend, Start: w.Saturday, End: w.Sunday, Amount: w.Left})
+	}
+	for _, s := range in.Subscriptions {
+		st := SubscriptionStatus(s, in.Expenses, in.Year, in.Month)
+		if !st.Paid {
+			continue
+		}
+		rollover += st.Diff
+		rolloverItems = append(rolloverItems, RolloverItem{Type: RolloverSubscription, Name: s.Name, Amount: st.Diff})
+	}
+
+	flexLeft := flexBudget + rollover - flexSpent
 	rows := []Row{
 		makeRow(EnvBelanja, shopBudget, shopSpent),
 		makeRow(EnvWeekend, wkndBudget, wkndSpent),
 		makeRow(EnvLangganan, subsAlloc, langgananSpent),
-		makeRow(EnvFleksibel, flexBudget, flexSpent),
+		{ID: EnvFleksibel, Label: EnvFleksibel.Label(), Budget: flexBudget, Spent: flexSpent, Left: flexLeft, Over: flexLeft < 0},
 	}
 
 	return MonthResult{
@@ -209,6 +263,8 @@ func ComputeMonth(in MonthInput) MonthResult {
 		SubsAlloc:      subsAlloc,
 		LanggananSpent: langgananSpent,
 		FlexSpent:      flexSpent,
+		Rollover:       rollover,
+		RolloverItems:  rolloverItems,
 		ShopBudget:     shopBudget,
 		ShopSpent:      shopSpent,
 		WkndBudget:     wkndBudget,

--- a/internal/envelope/engine_test.go
+++ b/internal/envelope/engine_test.go
@@ -164,12 +164,13 @@ func TestComputeMonth_June2026Seed(t *testing.T) {
 		}
 	}
 
-	// rows: belanja, weekend, langganan, fleksibel
+	// rows: belanja, weekend, langganan, fleksibel. Fleksibel's left includes
+	// the rollover (§6.6): 1470000 + 671000 − 38000.
 	wantRows := []Row{
 		{ID: EnvBelanja, Budget: 2_400_000, Spent: 742_000, Left: 1_658_000, Over: false},
 		{ID: EnvWeekend, Budget: 800_000, Spent: 178_000, Left: 622_000, Over: false},
 		{ID: EnvLangganan, Budget: 330_000, Spent: 251_000, Left: 79_000, Over: false},
-		{ID: EnvFleksibel, Budget: 1_470_000, Spent: 38_000, Left: 1_432_000, Over: false},
+		{ID: EnvFleksibel, Budget: 1_470_000, Spent: 38_000, Left: 2_103_000, Over: false},
 	}
 	if len(got.Rows) != 4 {
 		t.Fatalf("len(Rows) = %d, want 4", len(got.Rows))
@@ -272,6 +273,140 @@ func TestComputeMonth_EmptyMonth(t *testing.T) {
 	}
 	if got.Sisa != 5_000_000 {
 		t.Errorf("Sisa = %d, want 5000000", got.Sisa)
+	}
+}
+
+// ---- Rollover into Fleksibel (§6.6) ---------------------------------------
+
+func TestComputeMonth_RolloverJune2026Seed(t *testing.T) {
+	// Mid-month (today Jun 16): closed sources are weeks 1–2, weekends 1–2, and
+	// the two paid subscriptions (Netflix +1000, Spotify 55000−65000 = −10000).
+	got := ComputeMonth(MonthInput{
+		Year: 2026, Month: 6,
+		Today:         d(2026, 6, 16),
+		Config:        seedConfig(),
+		Subscriptions: seedSubs(),
+		Expenses:      seedExpenses(),
+	})
+
+	// 48000 + 410000 (weeks) + 22000 + 200000 (weekends) + 1000 − 10000 (subs).
+	if got.Rollover != 671_000 {
+		t.Errorf("Rollover = %d, want 671000", got.Rollover)
+	}
+
+	want := []RolloverItem{
+		{Type: RolloverWeek, Start: d(2026, 6, 1), End: d(2026, 6, 7), Amount: 48_000},
+		{Type: RolloverWeek, Start: d(2026, 6, 8), End: d(2026, 6, 14), Amount: 410_000},
+		{Type: RolloverWeekend, Start: d(2026, 6, 6), End: d(2026, 6, 7), Amount: 22_000},
+		{Type: RolloverWeekend, Start: d(2026, 6, 13), End: d(2026, 6, 14), Amount: 200_000},
+		{Type: RolloverSubscription, Name: "Netflix", Amount: 1_000},
+		{Type: RolloverSubscription, Name: "Spotify", Amount: -10_000},
+	}
+	if len(got.RolloverItems) != len(want) {
+		t.Fatalf("len(RolloverItems) = %d, want %d (unpaid subs must be absent)", len(got.RolloverItems), len(want))
+	}
+	for i, it := range got.RolloverItems {
+		w := want[i]
+		if it.Type != w.Type || it.Amount != w.Amount || it.Name != w.Name {
+			t.Errorf("item %d = %+v, want type=%s name=%q amount=%d", i, it, w.Type, w.Name, w.Amount)
+		}
+		if w.Type != RolloverSubscription && (!timeutil.SameDate(it.Start, w.Start) || !timeutil.SameDate(it.End, w.End)) {
+			t.Errorf("item %d range = %s..%s, want %s..%s",
+				i, it.Start.Format("2006-01-02"), it.End.Format("2006-01-02"),
+				w.Start.Format("2006-01-02"), w.End.Format("2006-01-02"))
+		}
+	}
+
+	// Rollover must not change sisa (already asserted in the seed test) and the
+	// planned flex budget stays untouched.
+	if got.FlexBudget != 1_470_000 {
+		t.Errorf("FlexBudget = %d, want 1470000 (rollover must not change the plan)", got.FlexBudget)
+	}
+}
+
+func TestComputeMonth_RolloverMonthStart(t *testing.T) {
+	// On the month's first day nothing is closed: no past pills, no paid subs.
+	got := ComputeMonth(MonthInput{Year: 2026, Month: 6, Today: d(2026, 6, 1), Config: seedConfig()})
+	if got.Rollover != 0 {
+		t.Errorf("Rollover = %d, want 0", got.Rollover)
+	}
+	if len(got.RolloverItems) != 0 {
+		t.Errorf("len(RolloverItems) = %d, want 0", len(got.RolloverItems))
+	}
+	// flexBudget = 5M − 2.4M − 0.8M (no subs) = 1.8M; left is untouched.
+	if got.Rows[3].Left != 1_800_000 {
+		t.Errorf("fleksibel left = %d, want 1800000", got.Rows[3].Left)
+	}
+}
+
+func TestComputeMonth_RolloverPastMonthView(t *testing.T) {
+	// Viewing June from July: every pill is past and payments are final, so the
+	// rollover is the month's full week+weekend+subscription leftover.
+	got := ComputeMonth(MonthInput{
+		Year: 2026, Month: 6,
+		Today:         d(2026, 7, 20),
+		Config:        seedConfig(),
+		Subscriptions: seedSubs(),
+		Expenses:      seedExpenses(),
+	})
+	// weeks 1658000 + weekends 622000 + subs (1000 − 10000).
+	if got.Rollover != 2_271_000 {
+		t.Errorf("Rollover = %d, want 2271000", got.Rollover)
+	}
+	if len(got.RolloverItems) != 10 { // 4 weeks + 4 weekends + 2 paid subs
+		t.Errorf("len(RolloverItems) = %d, want 10", len(got.RolloverItems))
+	}
+	if got.Rows[3].Left != 3_703_000 { // 1470000 + 2271000 − 38000
+		t.Errorf("fleksibel left = %d, want 3703000", got.Rows[3].Left)
+	}
+}
+
+func TestComputeMonth_NegativeRolloverPushesFlexOver(t *testing.T) {
+	// A heavily overspent past week drags fleksibel below zero even though
+	// nothing was spent from fleksibel itself.
+	exp := []Expense{{Date: d(2026, 6, 3), Amount: 4_000_000, Category: CatBelanja}}
+	got := ComputeMonth(MonthInput{Year: 2026, Month: 6, Today: d(2026, 6, 16), Config: seedConfig(), Expenses: exp})
+	// week1 −3.4M + week2 600K + weekends 2×200K = −2.4M.
+	if got.Rollover != -2_400_000 {
+		t.Errorf("Rollover = %d, want -2400000", got.Rollover)
+	}
+	flex := got.Rows[3]
+	if flex.Left != -600_000 { // 1800000 − 2400000 − 0
+		t.Errorf("fleksibel left = %d, want -600000", flex.Left)
+	}
+	if !flex.Over {
+		t.Error("fleksibel over = false, want true (negative rolled-up left)")
+	}
+}
+
+func TestComputeMonth_RolloverIncludesZeroAmountItems(t *testing.T) {
+	// A past week closed exactly on budget still appears in the breakdown.
+	exp := []Expense{{Date: d(2026, 6, 3), Amount: 600_000, Category: CatBelanja}}
+	got := ComputeMonth(MonthInput{Year: 2026, Month: 6, Today: d(2026, 6, 16), Config: seedConfig(), Expenses: exp})
+	if len(got.RolloverItems) != 4 { // weeks 1–2 + weekends 1–2
+		t.Fatalf("len(RolloverItems) = %d, want 4", len(got.RolloverItems))
+	}
+	if got.RolloverItems[0].Amount != 0 {
+		t.Errorf("week1 item amount = %d, want 0 (zero items are part of the audit trail)", got.RolloverItems[0].Amount)
+	}
+}
+
+func TestComputeMonth_RolloverFollowsWeekOwnership(t *testing.T) {
+	// A boundary week's leftover rolls in the month that OWNS the week (its
+	// Friday), same as its spent. Jun 29 belongs to July's first week.
+	exp := []Expense{{Date: d(2026, 6, 29), Amount: 100_000, Category: CatBelanja}}
+
+	july := ComputeMonth(MonthInput{Year: 2026, Month: 7, Today: d(2026, 8, 5), Config: seedConfig(), Expenses: exp})
+	first := july.RolloverItems[0]
+	if first.Type != RolloverWeek || !timeutil.SameDate(first.Start, d(2026, 6, 29)) || first.Amount != 500_000 {
+		t.Errorf("July first rollover item = %+v, want week starting 2026-06-29 with amount 500000", first)
+	}
+
+	june := ComputeMonth(MonthInput{Year: 2026, Month: 6, Today: d(2026, 8, 5), Config: seedConfig(), Expenses: exp})
+	// June's rollover is untouched by the Jun-29 expense: 4 full weeks + 4 full
+	// weekends = 2.4M + 0.8M.
+	if june.Rollover != 3_200_000 {
+		t.Errorf("June Rollover = %d, want 3200000 (Jun-29 belongs to July's week)", june.Rollover)
 	}
 }
 

--- a/internal/month/model.go
+++ b/internal/month/model.go
@@ -66,11 +66,24 @@ type WeekendDTO struct {
 	State    string `json:"state"`
 }
 
-// Flex is the flexible-envelope summary.
+// Flex is the flexible-envelope summary. Rollover is the §6.6 sum of closed
+// sources' leftover; Left = Budget + Rollover − Spent.
 type Flex struct {
-	Budget int64 `json:"budget"`
-	Spent  int64 `json:"spent"`
-	Left   int64 `json:"left"`
+	Budget        int64             `json:"budget"`
+	Rollover      int64             `json:"rollover"`
+	Spent         int64             `json:"spent"`
+	Left          int64             `json:"left"`
+	RolloverItems []RolloverItemDTO `json:"rollover_items"`
+}
+
+// RolloverItemDTO is one closed rollover source (spec §7.1): week/weekend
+// items carry start/end dates, subscription items carry the name.
+type RolloverItemDTO struct {
+	Type   string `json:"type"` // week | weekend | subscription
+	Start  string `json:"start,omitempty"`
+	End    string `json:"end,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Amount int64  `json:"amount"`
 }
 
 // CalendarDay is one cell of the month calendar grid.

--- a/internal/month/service.go
+++ b/internal/month/service.go
@@ -98,8 +98,14 @@ func (s *Service) Dashboard(ctx context.Context, year, month int) (Dashboard, er
 			IsCurrent: year == curY && month == curM,
 		},
 		Stats: Stats{Spent: result.TotalSpent, Budget: cfg.Monthly, Remaining: result.Sisa},
-		Flex:  Flex{Budget: result.FlexBudget, Spent: result.FlexSpent, Left: result.FlexBudget - result.FlexSpent},
-		Days:  map[string][]expense.Response{},
+		Flex: Flex{
+			Budget:        result.FlexBudget,
+			Rollover:      result.Rollover,
+			Spent:         result.FlexSpent,
+			Left:          result.FlexBudget + result.Rollover - result.FlexSpent,
+			RolloverItems: rolloverItems(result.RolloverItems),
+		},
+		Days: map[string][]expense.Response{},
 	}
 
 	for _, row := range result.Rows {
@@ -159,6 +165,23 @@ func (s *Service) Dashboard(ctx context.Context, year, month int) (Dashboard, er
 	}
 
 	return dash, nil
+}
+
+// rolloverItems maps engine rollover items to their §7.1 DTOs. It always
+// returns a non-nil slice so the payload serializes as [] rather than null.
+func rolloverItems(items []envelope.RolloverItem) []RolloverItemDTO {
+	dtos := make([]RolloverItemDTO, 0, len(items))
+	for _, it := range items {
+		dto := RolloverItemDTO{Type: string(it.Type), Amount: it.Amount}
+		if it.Type == envelope.RolloverSubscription {
+			dto.Name = it.Name
+		} else {
+			dto.Start = ymd(it.Start)
+			dto.End = ymd(it.End)
+		}
+		dtos = append(dtos, dto)
+	}
+	return dtos
 }
 
 // ymd formats a date as YYYY-MM-DD in Asia/Jakarta.

--- a/internal/month/service_test.go
+++ b/internal/month/service_test.go
@@ -121,6 +121,74 @@ func TestDashboard_Assembly(t *testing.T) {
 	}
 }
 
+func TestDashboard_FlexRollover(t *testing.T) {
+	// Clock on Tue Jun 23 2026: weeks 1–3 and weekends 1–3 are past; the one
+	// subscription is paid (alloc 187000, paid 186000 → +1000).
+	subID := uuid.New()
+	cfg := budget.Config{Monthly: 5_000_000, ShopWeekly: 600_000, WeekendBudget: 200_000}
+	subs := []subscription.Resolved{{ID: subID, Name: "Netflix", Color: "#c8403c", Alloc: 187_000, DueDay: 5}}
+	exps := []expense.Expense{
+		exp(timeutil.Date(2026, 6, 15), 18_000, "Makan", nil),        // week 3 belanja
+		exp(timeutil.Date(2026, 6, 5), 186_000, "Langganan", &subID), // paid sub
+		exp(timeutil.Date(2026, 6, 16), 8_000, "Lainnya", nil),       // fleksibel
+	}
+
+	svc := NewService(fakeBudget{cfg}, fakeSubs{subs}, fakeExpenses{exps}, fixedClock(2026, 6, 23))
+	dash, err := svc.Dashboard(context.Background(), 2026, 6)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+
+	// weeks 600000+600000+582000 + weekends 3×200000 + sub 1000.
+	if dash.Flex.Rollover != 2_383_000 {
+		t.Errorf("flex.rollover: got %d, want 2383000", dash.Flex.Rollover)
+	}
+	// flexBudget = 5M − 2.4M − 0.8M − 187000 = 1613000; left = budget + rollover − spent.
+	if dash.Flex.Budget != 1_613_000 {
+		t.Errorf("flex.budget: got %d, want 1613000", dash.Flex.Budget)
+	}
+	if dash.Flex.Left != 3_988_000 {
+		t.Errorf("flex.left: got %d, want 3988000", dash.Flex.Left)
+	}
+
+	items := dash.Flex.RolloverItems
+	if len(items) != 7 { // 3 weeks + 3 weekends + 1 paid sub
+		t.Fatalf("len(rollover_items) = %d, want 7", len(items))
+	}
+	first := items[0]
+	if first.Type != "week" || first.Start != "2026-06-01" || first.End != "2026-06-07" || first.Amount != 600_000 || first.Name != "" {
+		t.Errorf("first item = %+v, want week 2026-06-01..2026-06-07 amount 600000 without name", first)
+	}
+	sub := items[6]
+	if sub.Type != "subscription" || sub.Name != "Netflix" || sub.Amount != 1_000 || sub.Start != "" || sub.End != "" {
+		t.Errorf("sub item = %+v, want subscription Netflix amount 1000 without dates", sub)
+	}
+
+	// The fleksibel envelope row carries the same rolled-up left.
+	for _, r := range dash.Envelopes {
+		if r.ID == "fleksibel" && r.Left != 3_988_000 {
+			t.Errorf("fleksibel row left: got %d, want 3988000", r.Left)
+		}
+	}
+}
+
+func TestDashboard_FlexRolloverEmptyIsNotNull(t *testing.T) {
+	// Month start: nothing closed. rollover_items must serialize as [] (the
+	// client guards on the array), never null.
+	cfg := budget.Config{Monthly: 5_000_000, ShopWeekly: 600_000, WeekendBudget: 200_000}
+	svc := NewService(fakeBudget{cfg}, fakeSubs{}, fakeExpenses{}, fixedClock(2026, 6, 1))
+	dash, err := svc.Dashboard(context.Background(), 2026, 6)
+	if err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	if dash.Flex.Rollover != 0 {
+		t.Errorf("flex.rollover: got %d, want 0", dash.Flex.Rollover)
+	}
+	if dash.Flex.RolloverItems == nil || len(dash.Flex.RolloverItems) != 0 {
+		t.Errorf("rollover_items: got %#v, want empty non-nil slice", dash.Flex.RolloverItems)
+	}
+}
+
 func TestDashboard_RangeLabels(t *testing.T) {
 	cfg := budget.Config{Monthly: 5_000_000, ShopWeekly: 600_000, WeekendBudget: 200_000}
 	svc := NewService(fakeBudget{cfg}, fakeSubs{}, fakeExpenses{}, fixedClock(2026, 6, 23))


### PR DESCRIPTION
## Intent
Implement spec **D9/§6.6** (merged in #21): leftover from **closed** sources rolls into the Fleksibel envelope, both signs, with an itemized breakdown in the API.

## Scope
- **Engine** (`internal/envelope/engine.go`): new `RolloverType`/`RolloverItem`; `ComputeMonth` sums past week/weekend pills' `left` and paid subscriptions' `alloc − paid` (via the existing `SubscriptionStatus`). Fleksibel row: `left = flexBudget + rollover − flexSpent`, `over = left < 0`. `FlexBudget` and `sisa` unchanged. Engine stays pure.
- **Month payload** (`internal/month/`): `flex` gains `rollover` + `rollover_items` (§7.1) — week/weekend items carry `start`/`end`, subscription items carry `name`; serializes as `[]` (never `null`) since the client guards on the array. `flex.left` is now the rolled-up value.
- **Docs**: Phase 6 backend checkboxes ticked in the spec.

No schema, repo, or effective-dating changes.

## Test plan
TDD — each test watched failing before implementation:
- 7 new engine tests: June-2026 seed mid-month (exact 6-item breakdown incl. overpaid Spotify −10K / underpaid Netflix +1K), month start (rollover 0), past-month view (all 10 sources closed), negative rollover flipping fleksibel `over`, zero-amount items kept in the audit trail, unpaid subs absent, boundary week rolling in its owning month.
- 2 month-service tests: payload mapping (dates vs name per item type, rolled-up `left` on both `flex` and the envelope row) and empty-but-non-null `rollover_items`.
- Seed test's fleksibel row updated to the new spec'd value (1 432 000 → 2 103 000).
- `go test ./...`, `go vet`, `gofmt` all clean.
- **E2E smoke on devdb**: ran the `Expense` function with `TIME=2026-07-14`; `GET /month?year=2026&month=7` returns rollover 1 620 000 (2 past weeks + 2 past weekends, boundary week starting Jun 29 owned by July) and a future month returns `rollover: 0, rollover_items: []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)