### PR TITLE
fix: fleksibel envelope row carries the effective budget (planned + rollover)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ The backend is being **completely rewritten** from the v1 model (`weekly/`, `mon
 - **One routed `Expense` Cloud Function** (method+path router) instead of one function per operation.
 - **Subscription payments are ordinary expenses** (category `Langganan` + `subscription_id`); single transactions table; **at most one payment per subscription per calendar month**.
 - **Budgets + subscriptions are effective-dated**: read the latest version with effective month ≤ viewed month; writes are effective from the **current** month (past months stay frozen).
-- **Fleksibel rollover** (D9, 2026-07-14): leftover from **closed** sources — past week/weekend pills (`left`) and paid subscriptions (`alloc − paid`), both signs — rolls into Fleksibel's `left`, with an itemized `rollover_items` breakdown in `GET /month`. Planned budgets and `sisa` unchanged (spec §6.6).
+- **Fleksibel rollover** (D9, 2026-07-14): leftover from **closed** sources — past week/weekend pills (`left`) and paid subscriptions (`alloc − paid`), both signs — rolls into Fleksibel's `left`, with an itemized `rollover_items` breakdown in `GET /month`. The fleksibel envelope **row** carries the effective budget (`flexBudget + rollover`); the planned figure lives in `flex.budget`. `sisa` unchanged (spec §6.6).
 - AI screenshot import (`/scan`) is **deferred to Phase 2**.
 
 ## Commands

--- a/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
+++ b/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
@@ -305,7 +305,7 @@ Inputs: expenses (date, amount, category) **for the read window (§6.2)**, **res
 - `rollover` = Σ leftover from **closed** sources (§6.6): past week/weekend pills' `left` + paid subscriptions' `alloc − paid`.
 - `totalSpent = shopSpent + wkndSpent + langgananSpent + flexSpent`.
 - `sisa = monthly − totalSpent` (rollover does **not** change `sisa`).
-- `rows[4]`: belanja, weekend, **langganan** `{budget=subsAlloc, spent=langgananSpent}`, fleksibel — each `{ id, label, budget, spent, left, over }`. Fleksibel only: `left = flexBudget + rollover − flexSpent` and `over = left < 0`; the other rows keep `left = budget − spent`.
+- `rows[4]`: belanja, weekend, **langganan** `{budget=subsAlloc, spent=langgananSpent}`, fleksibel — each `{ id, label, budget, spent, left, over }` with `left = budget − spent`, `over = spent > budget`. Fleksibel's row `budget` is the **effective** figure `flexBudget + rollover` so the card's progress bar agrees with `over`; the planned `flexBudget` is exposed only via `flex.budget` (the detail-sheet ledger).
 
 `state` (week/weekend pills, port of `weekPillState`): **past** (`sun < today`) → final diff; **current** (`start ≤ today ≤ sun`) → `left`; **future** → `budget`.
 
@@ -327,6 +327,7 @@ Leftover from **closed** sources rolls into the Fleksibel envelope. A source is 
 
 - `rollover = Σ` contributions. Current/future pills and **unpaid subscriptions contribute nothing** — an unpaid sub's alloc stays fully reserved.
 - Fleksibel: `left = flexBudget + rollover − flexSpent`, `over = left < 0` (a bad week can push Fleksibel over even with modest flex spending — intended). The planned `flexBudget` and `sisa` are **unchanged**: rollover moves money between envelopes' `left`, never changes the month total.
+- The fleksibel **envelope row** (card) carries the effective budget `flexBudget + rollover`, so the progress bar and `over` flag tell the same story; the detail-sheet ledger keeps the planned figure (`flex.budget`) with the rollover itemized below it. *(Amended 2026-07-14 after preview review.)*
 - The engine also returns the itemized breakdown (`rollover_items`, §7.1) so the Fleksibel detail can show where every add/deduct came from: one item per closed source, **including zero amounts** (complete audit trail). Open sources are absent — absence means "still open".
 - Boundary weeks/weekends roll in the month that **owns** them (Friday/Saturday rule, §6.2), same as their `spent`.
 - Viewing a **past** month: every pill is past and payments are final ⇒ rollover is the month's full week+weekend+subscription leftover. Viewing a **future** month: nothing is closed ⇒ rollover 0. Both fall out of the rules above — no special-casing.
@@ -348,7 +349,7 @@ One routed function. JSON in/out. Errors: non-2xx with `{"error":"message"}` per
     { "id": "belanja",   "label": "Belanja Mingguan", "budget": 2400000, "spent": 980000, "left": 1420000, "over": false },
     { "id": "weekend",   "label": "Akhir Pekan",       "budget": 800000,  "spent": 254000, "left": 546000,  "over": false },
     { "id": "langganan", "label": "Langganan",         "budget": 330000,  "spent": 251000, "left": 79000,   "over": false },
-    { "id": "fleksibel", "label": "Fleksibel",         "budget": 1470000, "spent": 8000,   "left": 1577000, "over": false }
+    { "id": "fleksibel", "label": "Fleksibel",         "budget": 1585000, "spent": 8000,   "left": 1577000, "over": false }
   ],
   "belanja_weeks": [
     { "range": "1–7 Jun", "monday": "2026-06-01", "friday": "2026-06-05", "sunday": "2026-06-07",

--- a/internal/envelope/engine.go
+++ b/internal/envelope/engine.go
@@ -249,12 +249,14 @@ func ComputeMonth(in MonthInput) MonthResult {
 		rolloverItems = append(rolloverItems, RolloverItem{Type: RolloverSubscription, Name: s.Name, Amount: st.Diff})
 	}
 
-	flexLeft := flexBudget + rollover - flexSpent
+	// The fleksibel row carries the EFFECTIVE budget (planned + rollover) so
+	// the envelope card's progress bar agrees with the over flag; the planned
+	// figure stays in FlexBudget / the flex ledger (§6.6).
 	rows := []Row{
 		makeRow(EnvBelanja, shopBudget, shopSpent),
 		makeRow(EnvWeekend, wkndBudget, wkndSpent),
 		makeRow(EnvLangganan, subsAlloc, langgananSpent),
-		{ID: EnvFleksibel, Label: EnvFleksibel.Label(), Budget: flexBudget, Spent: flexSpent, Left: flexLeft, Over: flexLeft < 0},
+		makeRow(EnvFleksibel, flexBudget+rollover, flexSpent),
 	}
 
 	return MonthResult{

--- a/internal/envelope/engine_test.go
+++ b/internal/envelope/engine_test.go
@@ -164,13 +164,14 @@ func TestComputeMonth_June2026Seed(t *testing.T) {
 		}
 	}
 
-	// rows: belanja, weekend, langganan, fleksibel. Fleksibel's left includes
-	// the rollover (§6.6): 1470000 + 671000 − 38000.
+	// rows: belanja, weekend, langganan, fleksibel. Fleksibel's row carries the
+	// EFFECTIVE budget (flexBudget 1470000 + rollover 671000) so the card's
+	// progress bar agrees with the over flag (§6.6); left = budget − spent.
 	wantRows := []Row{
 		{ID: EnvBelanja, Budget: 2_400_000, Spent: 742_000, Left: 1_658_000, Over: false},
 		{ID: EnvWeekend, Budget: 800_000, Spent: 178_000, Left: 622_000, Over: false},
 		{ID: EnvLangganan, Budget: 330_000, Spent: 251_000, Left: 79_000, Over: false},
-		{ID: EnvFleksibel, Budget: 1_470_000, Spent: 38_000, Left: 2_103_000, Over: false},
+		{ID: EnvFleksibel, Budget: 2_141_000, Spent: 38_000, Left: 2_103_000, Over: false},
 	}
 	if len(got.Rows) != 4 {
 		t.Fatalf("len(Rows) = %d, want 4", len(got.Rows))
@@ -371,7 +372,10 @@ func TestComputeMonth_NegativeRolloverPushesFlexOver(t *testing.T) {
 		t.Errorf("Rollover = %d, want -2400000", got.Rollover)
 	}
 	flex := got.Rows[3]
-	if flex.Left != -600_000 { // 1800000 − 2400000 − 0
+	if flex.Budget != -600_000 { // effective: 1800000 − 2400000
+		t.Errorf("fleksibel effective budget = %d, want -600000", flex.Budget)
+	}
+	if flex.Left != -600_000 { // −600000 − 0 spent
 		t.Errorf("fleksibel left = %d, want -600000", flex.Left)
 	}
 	if !flex.Over {

--- a/internal/month/service_test.go
+++ b/internal/month/service_test.go
@@ -164,10 +164,16 @@ func TestDashboard_FlexRollover(t *testing.T) {
 		t.Errorf("sub item = %+v, want subscription Netflix amount 1000 without dates", sub)
 	}
 
-	// The fleksibel envelope row carries the same rolled-up left.
+	// The fleksibel envelope row carries the EFFECTIVE budget (planned +
+	// rollover) so the card's progress bar is honest, and the rolled-up left.
 	for _, r := range dash.Envelopes {
-		if r.ID == "fleksibel" && r.Left != 3_988_000 {
-			t.Errorf("fleksibel row left: got %d, want 3988000", r.Left)
+		if r.ID == "fleksibel" {
+			if r.Budget != 3_996_000 { // 1613000 + 2383000
+				t.Errorf("fleksibel row budget: got %d, want 3996000", r.Budget)
+			}
+			if r.Left != 3_988_000 {
+				t.Errorf("fleksibel row left: got %d, want 3988000", r.Left)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Intent
Follow-up to #22, found on the expense-web#18 preview: the envelope card's progress bar fills against the fleksibel row's `budget`, but that row carried the **planned** figure while its `over` flag already meant `spent > planned + rollover`. With a negative rollover the bar and the flag disagreed (bar ~58% while effectively at ~71% on current July data).

## Scope
- `internal/envelope/engine.go`: the fleksibel row is now `makeRow(fleksibel, flexBudget + rollover, flexSpent)` — `budget` is the **effective** figure; `left`/`over` values are unchanged (they were already effective, the row is just internally consistent now).
- The **planned** budget remains exposed as `flex.budget` for the detail-sheet ledger ("Jatah fleksibel" + itemized rollover below it).
- Spec §6.3/§6.6 + sample payload + CLAUDE.md synced.
- No frontend change needed — the card renders what it's given; the #18 preview picks this up as soon as it deploys (preview calls the production API).

## Test plan
TDD (all watched failing first):
- Engine seed test: fleksibel row budget 1 470 000 → 2 141 000 (effective), left unchanged.
- Negative-rollover test now asserts the effective budget goes negative with `over: true`.
- Month-service test asserts the row mapping (budget 3 996 000 = 1 613 000 + 2 383 000) alongside the planned `flex.budget`.
- `go test ./...`, `go vet`, `gofmt` clean.
- Live devdb smoke: row `budget: 2130000` (510K planned + 1.62Jt rollover) while `flex.budget` stays 510000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)