### PR TITLE
feat: group flex rollover_items by type (week/weekend/subscription sums)

### DIFF
--- a/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
+++ b/docs/superpowers/specs/2026-06-15-amplop-v2-backend-design.md
@@ -328,7 +328,7 @@ Leftover from **closed** sources rolls into the Fleksibel envelope. A source is 
 - `rollover = Σ` contributions. Current/future pills and **unpaid subscriptions contribute nothing** — an unpaid sub's alloc stays fully reserved.
 - Fleksibel: `left = flexBudget + rollover − flexSpent`, `over = left < 0` (a bad week can push Fleksibel over even with modest flex spending — intended). The planned `flexBudget` and `sisa` are **unchanged**: rollover moves money between envelopes' `left`, never changes the month total.
 - The fleksibel **envelope row** (card) carries the effective budget `flexBudget + rollover`, so the progress bar and `over` flag tell the same story; the detail-sheet ledger keeps the planned figure (`flex.budget`) with the rollover itemized below it. *(Amended 2026-07-14 after preview review.)*
-- The engine also returns the itemized breakdown (`rollover_items`, §7.1) so the Fleksibel detail can show where every add/deduct came from: one item per closed source, **including zero amounts** (complete audit trail). Open sources are absent — absence means "still open".
+- The engine returns the per-source breakdown (`RolloverItems`, including zero amounts; open sources absent). The **API groups it by type** (`rollover_items`, §7.1): one summed row per type — week, weekend, subscription — omitting types with no closed source, so the Fleksibel detail shows "Mingguan / Akhir pekan / Langganan" totals. *(Amended 2026-07-14: per-source items dropped from the payload in favor of type sums.)*
 - Boundary weeks/weekends roll in the month that **owns** them (Friday/Saturday rule, §6.2), same as their `spent`.
 - Viewing a **past** month: every pill is past and payments are final ⇒ rollover is the month's full week+weekend+subscription leftover. Viewing a **future** month: nothing is closed ⇒ rollover 0. Both fall out of the rules above — no special-casing.
 
@@ -362,9 +362,9 @@ One routed function. JSON in/out. Errors: non-2xx with `{"error":"message"}` per
   "flex": {
     "budget": 1470000, "rollover": 115000, "spent": 8000, "left": 1577000,
     "rollover_items": [
-      { "type": "week",         "start": "2026-06-01", "end": "2026-06-07", "amount": 168000 },
-      { "type": "weekend",      "start": "2026-06-06", "end": "2026-06-07", "amount": -54000 },
-      { "type": "subscription", "name": "Netflix",                          "amount": 1000 }
+      { "type": "week",         "amount": 168000 },
+      { "type": "weekend",      "amount": -54000 },
+      { "type": "subscription", "amount": 1000 }
     ]
   },
   "calendar": [
@@ -391,7 +391,7 @@ One routed function. JSON in/out. Errors: non-2xx with `{"error":"message"}` per
 
 `days` includes Langganan expenses as ordinary rows (no injection). Each expense carries `date` (the day-group key) and `occurred_at` (RFC3339; see §7.2). `subscriptions[].paid` is derived from this month's Langganan expense linked to each subscription (at most one).
 
-`flex.rollover_items` lists every **closed** rollover source (§6.6) — `week`/`weekend` items carry `start`/`end` dates, `subscription` items carry `name`; the client formats labels (e.g. "Minggu 1–7 Jun"). The fleksibel row in `envelopes` uses the rolled-up `left` (`budget + rollover − spent`).
+`flex.rollover_items` is the rollover **grouped by type** (§6.6): one summed row per type with ≥1 closed source, ordered week → weekend → subscription; the client maps types to labels ("Mingguan" / "Akhir pekan" / "Langganan"). The fleksibel row in `envelopes` carries the effective budget and rolled-up `left`.
 
 ### 7.2 Write — expenses (incl. subscription payments)
 - `POST /expenses` `{ date, time?, amount, category, subscription_id?, note? }` → created. `subscription_id` **required iff** `category=="Langganan"` (and must reference an existing subscription); must be null otherwise.

--- a/internal/month/model.go
+++ b/internal/month/model.go
@@ -76,13 +76,10 @@ type Flex struct {
 	RolloverItems []RolloverItemDTO `json:"rollover_items"`
 }
 
-// RolloverItemDTO is one closed rollover source (spec §7.1): week/weekend
-// items carry start/end dates, subscription items carry the name.
+// RolloverItemDTO is one rollover group (spec §7.1): the summed contribution
+// of every closed source of a type. Types with no closed source are omitted.
 type RolloverItemDTO struct {
 	Type   string `json:"type"` // week | weekend | subscription
-	Start  string `json:"start,omitempty"`
-	End    string `json:"end,omitempty"`
-	Name   string `json:"name,omitempty"`
 	Amount int64  `json:"amount"`
 }
 

--- a/internal/month/service.go
+++ b/internal/month/service.go
@@ -167,19 +167,23 @@ func (s *Service) Dashboard(ctx context.Context, year, month int) (Dashboard, er
 	return dash, nil
 }
 
-// rolloverItems maps engine rollover items to their §7.1 DTOs. It always
-// returns a non-nil slice so the payload serializes as [] rather than null.
+// rolloverItems groups the engine's per-source rollover items into one summed
+// DTO per type (week, weekend, subscription — §7.1), skipping types with no
+// closed source. It always returns a non-nil slice so the payload serializes
+// as [] rather than null.
 func rolloverItems(items []envelope.RolloverItem) []RolloverItemDTO {
-	dtos := make([]RolloverItemDTO, 0, len(items))
+	sums := map[envelope.RolloverType]int64{}
+	counts := map[envelope.RolloverType]int{}
 	for _, it := range items {
-		dto := RolloverItemDTO{Type: string(it.Type), Amount: it.Amount}
-		if it.Type == envelope.RolloverSubscription {
-			dto.Name = it.Name
-		} else {
-			dto.Start = ymd(it.Start)
-			dto.End = ymd(it.End)
+		sums[it.Type] += it.Amount
+		counts[it.Type]++
+	}
+	dtos := make([]RolloverItemDTO, 0, 3)
+	for _, t := range []envelope.RolloverType{envelope.RolloverWeek, envelope.RolloverWeekend, envelope.RolloverSubscription} {
+		if counts[t] == 0 {
+			continue
 		}
-		dtos = append(dtos, dto)
+		dtos = append(dtos, RolloverItemDTO{Type: string(t), Amount: sums[t]})
 	}
 	return dtos
 }

--- a/internal/month/service_test.go
+++ b/internal/month/service_test.go
@@ -151,17 +151,20 @@ func TestDashboard_FlexRollover(t *testing.T) {
 		t.Errorf("flex.left: got %d, want 3988000", dash.Flex.Left)
 	}
 
+	// Items are grouped by type: one summed row per type with ≥1 closed source.
+	want := []RolloverItemDTO{
+		{Type: "week", Amount: 1_782_000},     // 600000 + 600000 + 582000
+		{Type: "weekend", Amount: 600_000},    // 3 × 200000
+		{Type: "subscription", Amount: 1_000}, // Netflix 187000 − 186000
+	}
 	items := dash.Flex.RolloverItems
-	if len(items) != 7 { // 3 weeks + 3 weekends + 1 paid sub
-		t.Fatalf("len(rollover_items) = %d, want 7", len(items))
+	if len(items) != len(want) {
+		t.Fatalf("len(rollover_items) = %d, want %d", len(items), len(want))
 	}
-	first := items[0]
-	if first.Type != "week" || first.Start != "2026-06-01" || first.End != "2026-06-07" || first.Amount != 600_000 || first.Name != "" {
-		t.Errorf("first item = %+v, want week 2026-06-01..2026-06-07 amount 600000 without name", first)
-	}
-	sub := items[6]
-	if sub.Type != "subscription" || sub.Name != "Netflix" || sub.Amount != 1_000 || sub.Start != "" || sub.End != "" {
-		t.Errorf("sub item = %+v, want subscription Netflix amount 1000 without dates", sub)
+	for i, it := range items {
+		if it != want[i] {
+			t.Errorf("item %d = %+v, want %+v", i, it, want[i])
+		}
 	}
 
 	// The fleksibel envelope row carries the EFFECTIVE budget (planned +


### PR DESCRIPTION
## Intent
Per review on the expense-web#18 preview: the Fleksibel detail should show the rollover **grouped by type** — one summed row each for Mingguan / Akhir pekan / Langganan — instead of every closed week/weekend/subscription.

> **Stacked on #23** (same test file); base auto-retargets to `main` once #23 merges.

## Scope
- `internal/month/service.go`: `rolloverItems` sums the engine's per-source items per type (ordered week → weekend → subscription), **omitting types with no closed source**; still always a non-null array.
- `internal/month/model.go`: `RolloverItemDTO` slims to `{type, amount}` — `start`/`end`/`name` dropped from the payload.
- The **engine is untouched**: it keeps per-source `RolloverItems` (dates/names) internally; only the API shape changes. `flex.rollover` total unchanged.
- Spec §6.6 + §7.1 sample/note synced.

## Test plan
- TDD: `TestDashboard_FlexRollover` rewritten first (watched failing: 7 items vs 3 groups) — asserts exact grouped rows `week 1782000 / weekend 600000 / subscription 1000`.
- Empty-month test still guards the non-null `[]`.
- `go test ./...`, `go vet`, `gofmt` clean.
- Live devdb smoke via the real UI (with expense-web#18's matching update): sheet shows Rollover +1,62Jt → "Mingguan +1,2Jt" / "Akhir pekan +420K", Langganan row correctly absent with nothing paid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)